### PR TITLE
Use Climate Explorer maps

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,7 @@
 REACT_APP_CE_BACKEND_URL=https://services.pacificclimate.org/pcex/api
 REACT_APP_ENSEMBLE_NAME=p2a_files
 REACT_APP_MODEL_ID=PCIC12
+REACT_APP_EMISSIONS_SCENARIO=historical,rcp85
 REACT_APP_TILECACHE_URL=https://b.tile.pacificclimate.org/tilecache/tilecache.py
-REACT_APP_NCWMS_URL=http://www.plan2adapt.ca/ncWMS/wms
+REACT_APP_NCWMS_URL=https://services.pacificclimate.org/pcex/ncwms
 REACT_APP_EXTERNAL_TEXT=external-text/default.yaml

--- a/package-lock.json
+++ b/package-lock.json
@@ -4816,6 +4816,16 @@
         "sha.js": "^2.4.8"
       }
     },
+    "create-react-class": {
+      "version": "15.6.3",
+      "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.3.tgz",
+      "integrity": "sha512-M+/3Q6E6DLO6Yx3OwrWjwHBnvfXXYA7W+dFjt/ZDBemHO1DDZhsalX/NUtnTYclN6GfnBDRh4qRHjcDHmlJBJg==",
+      "requires": {
+        "fbjs": "^0.8.9",
+        "loose-envify": "^1.3.1",
+        "object-assign": "^4.1.1"
+      }
+    },
     "create-react-context": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.2.3.tgz",
@@ -15118,6 +15128,16 @@
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
+    "react-loader": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/react-loader/-/react-loader-2.4.5.tgz",
+      "integrity": "sha1-zT5VHGzQc4wcDxPwc2VPk4KL5ak=",
+      "requires": {
+        "create-react-class": "^15.5.2",
+        "prop-types": "^15.5.8",
+        "spin.js": "2.x"
+      }
+    },
     "react-markdown": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-4.0.8.tgz",
@@ -17384,6 +17404,11 @@
           }
         }
       }
+    },
+    "spin.js": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/spin.js/-/spin.js-2.3.2.tgz",
+      "integrity": "sha1-bKpW1SBnNFD9XPvGlx5tB3LDeho="
     },
     "split-string": {
       "version": "3.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12114,8 +12114,8 @@
       }
     },
     "pcic-react-components": {
-      "version": "git+https://git@github.com/pacificclimate/pcic-react-components.git#d1e4d17baf1e0e477f4fc0130d489838159bf195",
-      "from": "git+https://git@github.com/pacificclimate/pcic-react-components.git#3.0.0",
+      "version": "git+https://git@github.com/pacificclimate/pcic-react-components.git#14d818e05e4686f8e6d05a76fc2f6c4ee793f6d8",
+      "from": "git+https://git@github.com/pacificclimate/pcic-react-components.git#3.1.0",
       "requires": {
         "lodash": "^4.17.11",
         "memoize-one": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "js-yaml": "^3.13.1",
     "leaflet": "^1.4.0",
     "lodash": "^4.17.11",
-    "pcic-react-components": "git+https://git@github.com/pacificclimate/pcic-react-components.git#3.0.0",
+    "pcic-react-components": "git+https://git@github.com/pacificclimate/pcic-react-components.git#3.1.0",
     "pcic-react-external-text": "git+https://git@github.com/pacificclimate/pcic-react-external-text.git#1.0.0",
     "pcic-react-leaflet-components": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git",
     "proj4": "^2.5.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "react-dom": "^16.8.6",
     "react-icons": "^3.5.0",
     "react-leaflet": "^2.1.4",
+    "react-loader": "^2.4.5",
     "react-markdown": "^4.0.6",
     "react-scripts": "^2.1.8",
     "react-select": "^2.3.0",

--- a/src/HOCs/withAsyncData.js
+++ b/src/HOCs/withAsyncData.js
@@ -9,9 +9,7 @@
 // https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#fetching-external-data-when-props-change
 // This code is a fairly direct port of that example.
 //
-// Data fetching occurs when the value of `this.props[controlProp]` changes.
-// This is simpler, but adequate, special case of the general case that could
-// be handled by passing in a function that compares all relevant props.
+// Data fetching occurs when the value of `shouldLoadData()` is truthy.
 //
 // The fetched data is injected into the base component through a prop passed
 // to it named by `dataProp`.
@@ -21,9 +19,20 @@ import Loader from 'react-loader';
 
 
 export default function withAsyncData(
-  loadAsyncData,  // Async data fetcher. Returns a promise.
-  shouldLoadData, // Examines props to determine whether new data should be loaded
-  dataPropName    // Name of prop to pass data to base component through
+  // Async data fetcher. Returns a promise.
+  // Signature: `loadAsyncData(props)`.
+  // Invoked with props (`this.props`) passed to the component returned by
+  // this HOC.
+  loadAsyncData,
+
+  // Examines props to determine whether new data should be loaded.
+  // Signature: `shouldLoadData(prevProps, props)`.
+  // Invoked with previous and current props (`this.props`) passed to the
+  // component returned by this HOC.
+  shouldLoadData,
+
+  // Name of prop to pass data to base component through.
+  dataPropName
 ) {
   return function(BaseComponent) {
     return class extends React.Component {

--- a/src/HOCs/withAsyncData.js
+++ b/src/HOCs/withAsyncData.js
@@ -1,0 +1,87 @@
+// Higher-order function returning a Higher-Order Component (HOC) that injects
+// asynchronously fetched data into a component.
+//
+// (See https://reactjs.org/docs/higher-order-components.html#convention-maximizing-composability
+// for why this HOC is separated into two parts like this.)
+//
+// To manage asynchronous data fetching, this component follows React best
+// practice:
+// https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#fetching-external-data-when-props-change
+// This code is a fairly direct port of that example.
+//
+// Data fetching occurs when the value of `this.props[controlProp]` changes.
+// This is simpler, but adequate, special case of the general case that could
+// be handled by passing in a function that compares all relevant props.
+//
+// The fetched data is injected into the base component through a prop passed
+// to it named by `dataProp`.
+
+import React from 'react';
+import Loader from 'react-loader';
+
+
+export default function withAsyncData(
+  loadAsyncData,  // Async data fetcher. Returns a promise.
+  shouldLoadData, // Examines props to determine whether new data should be loaded
+  dataPropName    // Name of prop to pass data to base component through
+) {
+  return function(BaseComponent) {
+    return class extends React.Component {
+      state = {
+        prevProps: undefined,
+        externalData: null,
+      };
+
+      static getDerivedStateFromProps(props, state) {
+        // Store previous props in state so we can evaluate `shouldLoadData()`.
+        // Clear out previously-loaded data so we don't deliver stale data.
+        if (shouldLoadData(state.prevProps, props)) {
+          return {
+            externalData: null,
+            prevProps: props,  // Robust only if props are immutable
+          };
+        }
+
+        // No state update necessary
+        return null;
+      }
+
+      componentDidMount() {
+        this._loadAsyncData(this.props);
+      }
+
+      componentDidUpdate(prevProps, prevState) {
+        if (this.state.externalData === null) {
+          this._loadAsyncData(this.props);
+        }
+      }
+
+      componentWillUnmount() {
+        if (this._asyncRequest && this._asyncRequest.cancel) {
+          this._asyncRequest.cancel();
+        }
+      }
+
+      _loadAsyncData(...args) {
+        this._asyncRequest = loadAsyncData(...args).then(
+          externalData => {
+            this._asyncRequest = null;
+            this.setState({ externalData });
+          }
+        );
+      }
+
+      render() {
+        if (this.state.externalData === null) {
+          return <Loader/>;
+        }
+        return (
+          <BaseComponent
+            {...{ [dataPropName]: this.state.externalData }}
+            {...this.props}
+          />
+        );
+      }
+    }
+  }
+}

--- a/src/components/app-root/App/App.js
+++ b/src/components/app-root/App/App.js
@@ -46,7 +46,7 @@ export default class App extends Component {
     metadata: null,
     region: regions[0],
     futureTimePeriod: undefined,
-    season: seasons[0],
+    season: undefined,
     variable: undefined,
   };
 
@@ -230,7 +230,7 @@ export default class App extends Component {
                     <Row>
                       <Col lg={12}>
                         <T path='maps.title' data={{
-                          season: this.state.season.label,
+                          season: get('label', this.state.season),
                           variable: get('label', this.state.variable),
                           region: this.state.region.label,
                         }}/>
@@ -243,7 +243,7 @@ export default class App extends Component {
                         end_date: 1990,
                       }}
                       futureTimePeriod={futureTimePeriod}
-                      season={this.state.season.value}
+                      season={get('value', this.state.season)}
                       variable={get('value', this.state.variable)}
                       metadata={this.state.metadata}
                     />
@@ -267,7 +267,7 @@ export default class App extends Component {
                     <Row>
                       <Col lg={12}>
                         <T path='graph.title' data={{
-                          season: this.state.season.label,
+                          season: get('label', this.state.season),
                           variable: get('label', this.state.variable),
                           region: this.state.region.label,
                         }}/>

--- a/src/components/app-root/App/App.js
+++ b/src/components/app-root/App/App.js
@@ -8,7 +8,7 @@ import Tab from 'react-bootstrap/Tab';
 
 import { map, filter, slice, curry, get } from 'lodash/fp';
 
-import { getMetadata } from '../../../data-services/metadata';
+import { fetchSummaryMetadata } from '../../../data-services/metadata';
 import regions from '../../../assets/regions';
 import timePeriods from '../../../assets/time-periods';
 import seasons from '../../../assets/seasons';
@@ -51,8 +51,7 @@ export default class App extends Component {
   };
 
   componentDidMount() {
-    getMetadata()
-      .then(response => response.data)
+    fetchSummaryMetadata()
       .then(metadata => this.setState({ metadata }))
   }
 

--- a/src/components/app-root/App/App.js
+++ b/src/components/app-root/App/App.js
@@ -6,13 +6,11 @@ import Col from 'react-bootstrap/Col';
 import Tabs from 'react-bootstrap/Tabs';
 import Tab from 'react-bootstrap/Tab';
 
-import { map, filter, slice, curry, get } from 'lodash/fp';
+import filter from 'lodash/fp/filter';
+import get from 'lodash/fp/get';
 
 import { fetchSummaryMetadata } from '../../../data-services/metadata';
 import regions from '../../../assets/regions';
-import timePeriods from '../../../assets/time-periods';
-import seasons from '../../../assets/seasons';
-import variables from '../../../assets/variables';
 import summary from '../../../assets/summary';
 import rulebase from '../../../assets/rulebase';
 import ruleValues from '../../../assets/rule-results';
@@ -22,18 +20,16 @@ import AppHeader from '../AppHeader';
 
 import RegionSelector from '../../selectors/RegionSelector/RegionSelector';
 import TimePeriodSelector from '../../selectors/TimePeriodSelector';
-// import { TimePeriodSelector } from 'pcic-react-components';
-import SeasonSelector from '../../selectors/SeasonSelector/SeasonSelector';
-import VariableSelector from '../../selectors/VariableSelector/VariableSelector';
-import SelectorLabel from '../../misc/SelectorLabel/SelectorLabel';
+import SeasonSelector from '../../selectors/SeasonSelector';
+import VariableSelector from '../../selectors/VariableSelector';
+import SelectorLabel from '../../misc/SelectorLabel';
 
-import ChangeOverTimeGraph from '../../data-displays/ChangeOverTimeGraph/ChangeOverTimeGraph';
+import ChangeOverTimeGraph from '../../data-displays/ChangeOverTimeGraph';
 import Impacts from '../../data-displays/impacts/Impacts';
 import Rules from '../../data-displays/impacts/Rules';
 import TwoDataMaps from '../../maps/TwoDataMaps/TwoDataMaps';
 
 import styles from './App.css';
-import Table from 'react-bootstrap/Table';
 import Summary from '../../data-displays/Summary';
 
 const baselineTimePeriod = {

--- a/src/components/data-displays/ChangeOverTimeGraph/ChangeOverTimeGraph.js
+++ b/src/components/data-displays/ChangeOverTimeGraph/ChangeOverTimeGraph.js
@@ -20,7 +20,7 @@ export default class ChangeOverTimeGraph extends React.Component {
         {`
           Graph:
           ${this.props.region.label},
-          ${this.props.season.label},
+          ${get('label', this.props.season)},
           ${get('label', this.props.variable)}
           vs. Time period
         `}

--- a/src/components/maps/CanadaBaseMap/CanadaBaseMap.js
+++ b/src/components/maps/CanadaBaseMap/CanadaBaseMap.js
@@ -52,6 +52,7 @@ class CanadaBaseMap extends React.Component {
 
   render() {
     const center = _.pick(this.props.origin, 'lat', 'lng');
+    const { viewport, onViewportChange, onViewportChanged, onClick } = this.props;
     return (
         <Map
           crs={this.props.crs}
@@ -61,9 +62,7 @@ class CanadaBaseMap extends React.Component {
           maxZoom={10}
           maxBounds={L.latLngBounds([[40, -150], [90, -50]])}
           ref={this.props.mapRef}
-          viewport={this.props.viewport}
-          onViewportChange={this.props.onViewportChange}
-          onClick={this.props.onClick}
+          {...{ viewport, onViewportChange, onViewportChanged, onClick }}
         >
           <TileLayer
             attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'

--- a/src/components/maps/CanadaBaseMap/CanadaBaseMap.js
+++ b/src/components/maps/CanadaBaseMap/CanadaBaseMap.js
@@ -1,0 +1,81 @@
+/* eslint-disable no-trailing-spaces */
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import _ from 'lodash';
+import L from 'leaflet';
+
+import { Map, TileLayer } from 'react-leaflet';
+import 'proj4';
+import 'proj4leaflet';
+
+import './CanadaBaseMap.css';
+import { generateResolutions } from '../map-utils';
+
+
+class CanadaBaseMap extends React.Component {
+  // Notes:
+  // - Do we really want `crs`, `version`, `srs`, `origin` to be props?
+  //  These props are not passed in any existing code; only their default
+  //  values are used.
+
+  static propTypes = {
+    crs: PropTypes.object,
+    version: PropTypes.string,
+    srs: PropTypes.string,
+    origin: PropTypes.object,
+    mapRef: PropTypes.func,
+  };
+
+  static defaultProps = {
+    crs: new L.Proj.CRS(
+      'EPSG:4326',
+      '+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs',
+      {
+        resolutions: generateResolutions(0.09765625, 10),
+        // If we don't set the origin correctly, then the projection transforms BC Albers coordinates to lat-lng
+        // coordinates incorrectly. You have to know the magic origin value.
+        //
+        // It is also probably important to know that the bc_osm tile set is a TMS tile set, which has axes
+        // transposed with respect to Leaflet axes. The proj4leaflet documentation incorrectly states that
+        // there is a CRS constructor `L.Proj.CRS.TMS` for TMS tilesets. It is absent in the version
+        // (1.0.2) we are using. It exists in proj4leaflet ver 0.7.1 (formerly in use here), and shows that the
+        // correct value for the origin option is `[bounds[0], bounds[3]]`, where `bounds` is the 3rd argument
+        // of the TMS constructor.
+        origin: [-150, 90],
+      }
+    ),
+    version: '1.1.1',
+    srs: 'EPSG:4326',
+    origin: { lat: 60, lng: -100, zoom: 0 },
+  };
+
+  render() {
+    const center = _.pick(this.props.origin, 'lat', 'lng');
+    return (
+        <Map
+          crs={this.props.crs}
+          center={center}
+          zoom={this.props.origin.zoom}
+          minZoom={0}
+          maxZoom={10}
+          maxBounds={L.latLngBounds([[40, -150], [90, -50]])}
+          ref={this.props.mapRef}
+          viewport={this.props.viewport}
+          onViewportChange={this.props.onViewportChange}
+          onClick={this.props.onClick}
+        >
+          <TileLayer
+            attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+            url={process.env.REACT_APP_TILECACHE_URL + '/1.0.0/na_4326_osm/{z}/{x}/{y}.png'}
+            subdomains={'abc'}
+            noWrap
+            maxZoom={12}
+          />
+          { this.props.children }
+        </Map>
+    );
+  }
+}
+
+export default CanadaBaseMap;

--- a/src/components/maps/CanadaBaseMap/package.json
+++ b/src/components/maps/CanadaBaseMap/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "CanadaBaseMap",
+  "version": "0.0.0",
+  "private": true,
+  "main": "./CanadaBaseMap.js"
+}

--- a/src/components/maps/DataMap/DataMap.js
+++ b/src/components/maps/DataMap/DataMap.js
@@ -7,16 +7,21 @@ import _ from 'lodash';
 import isEqual from 'lodash/fp/isEqual';
 import flow from 'lodash/fp/flow';
 import filter from 'lodash/fp/filter';
-import pick from 'lodash/fp/pick';
+import map from 'lodash/fp/map';
 import mapValues from 'lodash/fp/mapValues';
+import keys from 'lodash/fp/keys';
+import fromPairs from 'lodash/fp/fromPairs';
 
 import { BCBaseMap } from 'pcic-react-leaflet-components';
+import CanadaBaseMap from '../CanadaBaseMap';
 import { WMSTileLayer } from 'react-leaflet';
 import LayerValuePopup from '../LayerValuePopup';
 import withAsyncData from '../../../HOCs/withAsyncData';
 
 import './DataMap.css';
 import { fetchFileMetadata } from '../../../data-services/metadata';
+export const mapValuesWithKey = mapValues.convert({ cap: false });
+export const filterWithKey = filter.convert({ cap: false });
 
 
 
@@ -105,6 +110,8 @@ const getLayerInfo = ({ layerSpec, layerPoint: xy }) => {
 };
 
 
+let count = 0;
+
 class DataMapDisplay extends React.Component {
   // This is a pure (state-free), controlled component that renders the
   // entire content of DataMap.
@@ -162,8 +169,23 @@ class DataMapDisplay extends React.Component {
     ...this.props.popup, isOpen: false, value: null,
   });
 
+  componentDidUpdate(prevProps, prevState, snapshot) {
+    console.log('### DataMap: cdu: prop changes',
+      flow(
+        keys,
+        filter(key => this.props[key] !== prevProps[key]),
+        map(key => [key, { prev: prevProps[key], curr: this.props[key]}]),
+        fromPairs,
+      )(prevProps)
+    )
+  }
+
   render() {
-    console.log('### DataMap', this.props)
+    console.log('### DataMap: count', count)
+    console.log('### DataMap: props', this.props)
+    if (count++ > 1000) {
+      throw new Error('DataMap: Too many renders')
+    }
 
     const { viewport, onViewportChange } = this.props;
 

--- a/src/components/maps/DataMap/DataMap.js
+++ b/src/components/maps/DataMap/DataMap.js
@@ -181,17 +181,14 @@ class DataMapDisplay extends React.Component {
   }
 
   render() {
-    console.log('### DataMap: count', count)
-    console.log('### DataMap: props', this.props)
-    if (count++ > 1000) {
-      throw new Error('DataMap: Too many renders')
-    }
-
-    const { viewport, onViewportChange } = this.props;
+    // console.log(`### DataMap [${this.props.id}]: wmsTileLayerProps`,
+    //   wmsTileLayerProps(this.props))
+    const { viewport, onViewportChange, onViewportChanged } = this.props;
 
     return (
-      <BCBaseMap {...{ viewport, onViewportChange }}
-                 onClick={this.handleClickMap}
+      <CanadaBaseMap
+        {...{ viewport, onViewportChange, onViewportChanged }}
+        onClick={this.handleClickMap}
       >
         <WMSTileLayer
           url={process.env.REACT_APP_NCWMS_URL}
@@ -204,7 +201,7 @@ class DataMapDisplay extends React.Component {
             onClose={this.handleClosePopup}
           />
         }
-      </BCBaseMap>
+      </CanadaBaseMap>
     );
   }
 }

--- a/src/components/maps/DataMap/DataMap.js
+++ b/src/components/maps/DataMap/DataMap.js
@@ -141,6 +141,11 @@ class DataMapDisplay extends React.Component {
     fileMetadata: PropTypes.object,
   };
 
+  // TODO: This code is currently disabled because the CE ncWMS does not allow
+  //  GetFeatureInfo requests, which are required to fill the popup with data.
+  //  ALSO, this code looks suspect to me; specifically, does it actually
+  //  implement a controlled component on props.popup, and fetch the relevant
+  //  data for each map (layer)?
   handleClickMap = (event) => {
     console.log('map click ', event)
     // Open popup on map
@@ -192,7 +197,9 @@ class DataMapDisplay extends React.Component {
     return (
       <CanadaBaseMap
         {...{ viewport, onViewportChange, onViewportChanged }}
-        onClick={this.handleClickMap}
+        // FIXME: Popups are disabled because the CE ncWMS does not allow
+        //  GetFeatureInfo requests, which are required to fill the popup.
+        // onClick={this.handleClickMap}
       >
         <WMSTileLayer
           url={process.env.REACT_APP_NCWMS_URL}

--- a/src/components/maps/TwoDataMaps/TwoDataMaps.js
+++ b/src/components/maps/TwoDataMaps/TwoDataMaps.js
@@ -1,3 +1,29 @@
+// This component renders two `DataMap`s, one with a baseline climate layer
+// and one with a user-selected climate layer. Map viewports are coordinated.
+// That is, when one map's viewport is changed (panned, zoomed), the other
+// map's viewport is set to the same value.
+//
+// Note on viewport coordination code.
+//
+// We pass in a simple handler as `onViewportChanged` to each `DataMap`.
+// This callback is called when a change of viewport (pan, zoom) is
+// complete, and does not fire continuously during such changes, as
+// `onViewportChange` (no d) does.
+//
+// User experience would be smoother if we used the callback `onViewportChange`,
+// but viewport change events are generated at a very high rate during active
+// changes, and this swamps the UI. (This may also be because there is
+// some kind of compounding of events between the two maps. Debugging
+// code (now removed) showed that even after a single change to the
+// viewport (`state.viewport`), the second map calls back with a slightly
+// different viewport, which then updates the first map.)
+//
+// Change events can easily be throttled (use `_.throttle`), but a wait time
+// of at least 100 ms is required to prevent event swamping. That leads to
+// jerky, laggy tracking of one viewport by the other. It was judged
+// a better user experience simply to have the other viewport updated once
+// at the end of changing.
+
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Row, Col } from 'react-bootstrap';
@@ -36,8 +62,9 @@ export default class TwoDataMaps extends React.Component {
             end_date: this.props.historicalTimePeriod.end_date
           }}/>
           <DataMap
+            id={'historical'}
             viewport={this.state.viewport}
-            onViewportChange={this.handleChangeViewport}
+            onViewportChanged={this.handleChangeViewport}
             popup={this.state.popup}
             onPopupChange={this.handleChangePopup}
             region={this.props.region}
@@ -53,8 +80,9 @@ export default class TwoDataMaps extends React.Component {
             end_date: this.props.futureTimePeriod.end_date
           }}/>
           <DataMap
+            id={'projected'}
             viewport={this.state.viewport}
-            onViewportChange={this.handleChangeViewport}
+            onViewportChanged={this.handleChangeViewport}
             popup={this.state.popup}
             onPopupChange={this.handleChangePopup}
             region={this.props.region}

--- a/src/components/maps/TwoDataMaps/TwoDataMaps.js
+++ b/src/components/maps/TwoDataMaps/TwoDataMaps.js
@@ -13,6 +13,7 @@ export default class TwoDataMaps extends React.Component {
     futureTimePeriod: PropTypes.object,
     season: PropTypes.string,
     variable: PropTypes.string,
+    metadata: PropTypes.array,
   };
 
   state = {
@@ -43,6 +44,7 @@ export default class TwoDataMaps extends React.Component {
             season={this.props.season}
             variable={this.props.variable}
             timePeriod={this.props.historicalTimePeriod}
+            metadata={this.props.metadata}
           />
         </Col>
         <Col lg={6}>
@@ -59,6 +61,7 @@ export default class TwoDataMaps extends React.Component {
             season={this.props.season}
             variable={this.props.variable}
             timePeriod={this.props.futureTimePeriod}
+            metadata={this.props.metadata}
           />
         </Col>
       </Row>

--- a/src/components/maps/map-utils.js
+++ b/src/components/maps/map-utils.js
@@ -1,0 +1,11 @@
+var generateResolutions = function (maxRes, count) {
+  var result = new Array(count);
+  for (var i = 0; i < result.length; i++) {
+    result[i] = maxRes / Math.pow(2, i);
+  }
+  return result;
+};
+
+export {
+  generateResolutions,
+};

--- a/src/components/selectors/SeasonSelector/SeasonSelector.js
+++ b/src/components/selectors/SeasonSelector/SeasonSelector.js
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import Select from 'react-select';
-import seasons from '../../../assets/seasons';
+import { TimeOfYearSelector } from 'pcic-react-components';
 
 
 export default class SeasonSelector extends React.Component {
@@ -12,10 +11,9 @@ export default class SeasonSelector extends React.Component {
 
   render() {
     return (
-      <Select
-        options={seasons}
-        value={this.props.value}
-        onChange={this.props.onChange}
+      <TimeOfYearSelector
+        {...this.props}
+        monthly={false}
       />
     );
   }

--- a/src/components/selectors/TimePeriodSelector/TimePeriodSelector.js
+++ b/src/components/selectors/TimePeriodSelector/TimePeriodSelector.js
@@ -3,6 +3,14 @@ import React from 'react';
 import { SimpleConstraintGroupingSelector } from 'pcic-react-components';
 
 
+const getOptionRepresentative = ({ start_date, end_date }) =>
+  ({ start_date, end_date });
+
+const getOptionLabel = ({ value: { representative: { start_date, end_date } } }) => {
+  const decade = Math.floor((Number(start_date) + Number(end_date)) / 20 ) * 10;
+  return `${decade}s (${start_date}–${end_date})`;
+};
+
 export default class TimePeriodSelector extends React.Component {
   static propTypes = {
     bases: PropTypes.array.isRequired,
@@ -16,23 +24,11 @@ export default class TimePeriodSelector extends React.Component {
     onChange: PropTypes.func,
   };
 
-  static getOptionRepresentative = ({ start_date, end_date }) => {
-    const decade = Math.floor((Number(start_date) + Number(end_date)) / 20 ) * 10;
-    return {
-      decade,
-      start_date: decade - 10,
-      end_date: decade + 20,
-    };
-  };
-
-  static getOptionLabel = ({ value: { representative: { decade, start_date, end_date } } }) =>
-    `${decade}s (${start_date}–${end_date})`;
-
   render() {
     return (
       <SimpleConstraintGroupingSelector
-        getOptionRepresentative={TimePeriodSelector.getOptionRepresentative}
-        getOptionLabel={TimePeriodSelector.getOptionLabel}
+        getOptionRepresentative={getOptionRepresentative}
+        getOptionLabel={getOptionLabel}
         {...this.props}
       />
     );

--- a/src/data-services/metadata.js
+++ b/src/data-services/metadata.js
@@ -67,7 +67,7 @@ export function fetchSummaryMetadata() {
 }
 
 
-const normalizeFileMetadata =
+export const normalizeFileMetadata =
   // Transform the unnecessarily nested dict returned by the backend
   // `/metadata` endpoint to an object one level shallower and with an
   // explicit name for the single top-level key (unique_id). This will have

--- a/src/data-services/metadata.js
+++ b/src/data-services/metadata.js
@@ -1,38 +1,46 @@
 import axios from 'axios';
 import urljoin from 'url-join';
 import flow from 'lodash/fp/flow';
+import filter from 'lodash/fp/filter';
 import map from 'lodash/fp/map';
 import flatten from 'lodash/fp/flatten';
+import tap from 'lodash/fp/tap';
+import groupBy from 'lodash/fp/groupBy';
+import head from 'lodash/fp/head';
 export const mapWithKey = map.convert({ cap: false });
 
 
 const getYear = timestamp => timestamp.substr(0, 4);
 
 
-export const standardize = flow(
-  // Map dict to array of array of standardized items. Each standardized item
-  // has a unique combination of values for unique_id, variable_id, and 
-  // variable_name, unrolled from the dicts in the original data,
-  // along with all the other properties that came with the dict.
-  // Properties start_date and end_date are truncated to year only.
-  mapWithKey(({ variables, start_date, end_date, ...rest }, unique_id) =>
-    mapWithKey((variable_name, variable_id) => ({
-      unique_id,
-      variable_id,
-      variable_name,
-      start_date: getYear(start_date),
-      end_date: getYear(end_date),
-      ...rest
-    }))(variables)
-  ),
-  
-  // And flatten the nested arrays.
-  flatten,
-);
+export const standardizeSummaryMetadata =
+  // Unroll the dict returned by backend `/multimeta` endpoint to an array.
+  // Each array item has a unique combination of values for `unique_id`,
+  // `variable_id`, and `variable_name`, unrolled from the dicts in the
+  // original data, along with all the other properties that came with the
+  // dict. Properties `start_date` and `end_date` are truncated to year only.
+  // TODO: Convert date strings to Date objects instead?
+  flow(
+    mapWithKey(({ variables, start_date, end_date, ...rest }, unique_id) =>
+      mapWithKey((variable_name, variable_id) => ({
+        unique_id,
+        variable_id,
+        variable_name,
+        start_date: getYear(start_date),
+        end_date: getYear(end_date),
+        ...rest
+      }))(variables)
+    ),
+
+    // And flatten the nested arrays.
+    flatten,
+  );
 
 
-export function getMetadata() {
-  console.log('getMetadata()')
+export function fetchSummaryMetadata() {
+  // Fetch the summary metadata provided by the backend `/multimeta` endpoint.
+
+  console.log('fetchSummaryMetadata()')
   return axios.get(
     urljoin(process.env.REACT_APP_CE_BACKEND_URL, 'multimeta'),
     {
@@ -40,7 +48,53 @@ export function getMetadata() {
         ensemble_name: process.env.REACT_APP_ENSEMBLE_NAME,
         model: process.env.REACT_APP_MODEL_ID,
       },
-      transformResponse: [JSON.parse, standardize],
+      transformResponse: [JSON.parse, standardizeSummaryMetadata],
     },
   )
+  .then(response => response.data)
+  .then(filter({
+    experiment: process.env.REACT_APP_EMISSIONS_SCENARIO,
+  }))
+  .then(tap(metadata => {
+    console.log('### Metadata loaded')
+    console.log('### Models', groupBy('model_id')(metadata))
+    console.log('### Scenario', groupBy('experiment')(metadata))
+    console.log('### Variables', groupBy('variable_id')(metadata))
+    console.log('### Run', groupBy('ensemble_member')(metadata))
+    console.log('### Period', groupBy(m => `${m.start_date}-${m.end_date}`)(metadata))
+    console.log('### Timescale', groupBy('timescale')(metadata))
+  }))
+}
+
+
+const normalizeFileMetadata =
+  // Transform the unnecessarily nested dict returned by the backend
+  // `/metadata` endpoint to an object one level shallower and with an
+  // explicit name for the single top-level key (unique_id). This will have
+  // to be done by any user of this information anyway, might as well do it
+  // right here at the origin.
+  flow(
+    mapWithKey((content, unique_id) => ({
+      unique_id,
+      ...content,
+    })),
+    head,
+  );
+
+export function fetchFileMetadata(unique_id) {
+  // Fetch the detailed metadata for a single file identified by `unique_id`
+  // from the backend `/metadata` endpoint.
+
+  return axios.get(
+    urljoin(process.env.REACT_APP_CE_BACKEND_URL, 'metadata'),
+    {
+      params: {
+        // Note misleading naming: API param `model_id` should actually be
+        // named `unique_id`.
+        model_id: unique_id,
+      },
+      transformResponse: [JSON.parse, normalizeFileMetadata],
+    },
+  )
+  .then(response => response.data)
 }

--- a/src/data-services/metadata.test.js
+++ b/src/data-services/metadata.test.js
@@ -1,7 +1,7 @@
-import { standardize } from './metadata';
+import { standardizeSummaryMetadata } from './metadata';
 import sortBy from 'lodash/fp/sortBy';
 
-describe('standardize', () => {
+describe('standardizeSummaryMetadata', () => {
   const rest = i => ({
     x: `x${i}`,
     y: `y${i}`,
@@ -61,6 +61,6 @@ describe('standardize', () => {
   ];
 
   it('works', () => {
-    expect(sortBy('unique_id')(standardize(data))).toEqual(normalized);
+    expect(sortBy('unique_id')(standardizeSummaryMetadata(data))).toEqual(normalized);
   });
 });

--- a/src/data-services/metadata.test.js
+++ b/src/data-services/metadata.test.js
@@ -1,12 +1,13 @@
-import { standardizeSummaryMetadata } from './metadata';
+import { standardizeSummaryMetadata, normalizeFileMetadata } from './metadata';
 import sortBy from 'lodash/fp/sortBy';
 
-describe('standardizeSummaryMetadata', () => {
-  const rest = i => ({
-    x: `x${i}`,
-    y: `y${i}`,
-  });
 
+const rest = i => ({
+  x: `x${i}`,
+  y: `y${i}`,
+});
+
+describe('standardizeSummaryMetadata', () => {
   const year = (i, j) => `2${i}0${j}`;
   const years = i => ({
     start_date: year(i, 1),
@@ -62,5 +63,23 @@ describe('standardizeSummaryMetadata', () => {
 
   it('works', () => {
     expect(sortBy('unique_id')(standardizeSummaryMetadata(data))).toEqual(normalized);
+  });
+});
+
+
+describe('normalizeFileMetadata', () => {
+  const data = {
+    giraffe_elephant: {
+      ...rest(1)
+    }
+  };
+
+  const normalized = {
+    unique_id: 'giraffe_elephant',
+    ...rest(1)
+  };
+
+  it('works', () => {
+    expect(normalizeFileMetadata(data)).toEqual(normalized);
   });
 });


### PR DESCRIPTION
Resolves #5 

Additionally:
- Filters metadata by a single model and emissions scenario, each configured in an environment variable.
- Replaces `SeasonSelector` with pcic-react-components `TimeOfYearSelector`.
- Changes `TimePeriodSelector` to use start and end dates taken from metadata.
- Replaces `BCBaseMap` with `CanadaBaseMap` because, voila, CE ncWMS can't supply tiles in BC Albers projection. :(
- Disables map popups because, voila, CE ncWMS doesn't support the necessary GetFeatureInfo request. :(