### PR TITLE
Get summary stats from backend (faked)

### DIFF
--- a/.env
+++ b/.env
@@ -7,3 +7,4 @@ REACT_APP_NCWMS_URL=https://services.pacificclimate.org/pcex/ncwms
 REACT_APP_EXTERNAL_TEXT=external-text/default.yaml
 REACT_APP_REGIONS_SERVICE_URL=http://docker-dev01.pcic.uvic.ca:30123/geoserver/bc_regions/ows
 REACT_APP_RULES_ENGINE_URL=http://docker-dev02.pcic.uvic.ca:30666
+REACT_APP_SUMMARY_STATISTICS_URL=foo

--- a/.env
+++ b/.env
@@ -1,10 +1,10 @@
 REACT_APP_CE_BACKEND_URL=https://services.pacificclimate.org/pcex/api
+REACT_APP_SUMMARY_STATISTICS_URL=fake
+REACT_APP_TILECACHE_URL=https://b.tile.pacificclimate.org/tilecache/tilecache.py
+REACT_APP_NCWMS_URL=https://services.pacificclimate.org/pcex/ncwms
+REACT_APP_REGIONS_SERVICE_URL=http://docker-dev01.pcic.uvic.ca:30123/geoserver/bc_regions/ows
+REACT_APP_RULES_ENGINE_URL=http://docker-dev02.pcic.uvic.ca:30666
 REACT_APP_ENSEMBLE_NAME=p2a_files
 REACT_APP_MODEL_ID=PCIC12
 REACT_APP_EMISSIONS_SCENARIO=historical,rcp85
-REACT_APP_TILECACHE_URL=https://b.tile.pacificclimate.org/tilecache/tilecache.py
-REACT_APP_NCWMS_URL=https://services.pacificclimate.org/pcex/ncwms
 REACT_APP_EXTERNAL_TEXT=external-text/default.yaml
-REACT_APP_REGIONS_SERVICE_URL=http://docker-dev01.pcic.uvic.ca:30123/geoserver/bc_regions/ows
-REACT_APP_RULES_ENGINE_URL=http://docker-dev02.pcic.uvic.ca:30666
-REACT_APP_SUMMARY_STATISTICS_URL=foo

--- a/public/external-text/default.yaml
+++ b/public/external-text/default.yaml
@@ -32,6 +32,29 @@ summary:
       range: |
         ${format(season.range.min)}${isLong(units) ? '': units} to
         ${format(season.range.max)}${units}
+    contents:
+      - variable: tasmean
+        seasons:
+          - annual
+      - variable: pr
+        seasons:
+          - annual
+          - summer
+          - winter
+      - variable: prsn
+        seasons:
+          - winter
+          - spring
+# TODO: Uncomment when stats backend complete
+#      - variable: gdd
+#        seasons:
+#          - annual
+#      - variable: hdd
+#        seasons:
+#          - annual
+#      - variable: fdETCCDI
+#        seasons:
+#          - annual
   notes:
     general: |
       The table above shows projected changes in average (mean) temperature,

--- a/src/assets/summary.js
+++ b/src/assets/summary.js
@@ -1,104 +1,76 @@
-export default [
-  {
-    variable: {
-      label: 'Mean Temperature',
-      units: '°C',
-    },
-    seasons: [
-      {
-        label: 'Annual',
-        ensembleMedian: 1.8,
-        range: { min: 1.3, max: 2.7, },
+// Faked up summary stats
+// Follows new API
+// Outer dict is keyed by variable only; No regions, time periods, percentiles
+
+export default {
+  "tasmean": {
+    "units": "degC",
+    "percentiles": [10, 50, 90],
+    "region": "vancouver_island",
+    "climatology": 2020,
+    "variable": "tasmean",
+    "data": {
+      "annual": {
+        "2020-07-01T00:00:00Z": [1.6, 1.7, 1.9]
       },
-    ]
+      "seasonal":{
+        "2020-01-15T00:00:00Z": [-1.5, -1.3, -1.1],
+        "2020-04-15T00:00:00Z": [0.0, 0.6, 1.2],
+        "2020-07-15T00:00:00Z": [2.1, 2.4, 2.8,],
+        "2020-10-15T00:00:00Z": [-0.3, -0.2, -0.1],
+      },
+      "monthly": {
+        "2020-01-15T00:00:00Z": [-1.5, -1.4, -1.3],
+        "2020-02-15T00:00:00Z": [-0.6, -0.5, -0.3],
+        "2020-03-15T00:00:00Z": [0.0, 0.2, 0.3],
+        "2020-04-15T00:00:00Z": [0.3, 0.4, 0.6],
+        "2020-05-15T00:00:00Z": [0.7, 0.75, 0.8],
+        "2020-06-15T00:00:00Z": [1.8, 2.0, 2.4],
+        "2020-07-15T00:00:00Z": [3.3, 3.5, 3.6],
+        "2020-08-15T00:00:00Z": [1.6, 1.7, 1.8],
+        "2020-09-15T00:00:00Z": [0.0, 0.1, 0.2],
+        "2020-10-15T00:00:00Z": [-0.3, -0.1, 0.0],
+        "2020-11-15T00:00:00Z": [-0.5, -0.4, -0.3],
+        "2020-12-15T00:00:00Z": [-1.3, -1.25, -1.2]
+      }
+    }
   },
 
-  {
-    variable: {
-      label: 'Precipitation',
-      units: '%',
-    },
-    seasons: [
-      {
-        label: 'Annual',
-        ensembleMedian: 6,
-        range: { min: 2, max: 12, },
+  "pr": {
+    "units": "%",
+    "percentiles": [10, 50, 90],
+    "region": "vancouver_island",
+    "climatology": 2020,
+    "variable": "pr",
+    "data": {
+      "annual": {
+        "2020-07-01T00:00:00Z": [2, 6, 12]
       },
-      {
-        label: 'Summer',
-        ensembleMedian: -1,
-        range: { min: -8, max: 6, },
+      "seasonal":{
+        "2020-01-15T00:00:00Z": [2, 8, 15],
+        "2020-04-15T00:00:00Z": [3, 6, 9],
+        "2020-07-15T00:00:00Z": [-8, -1, 6],
+        "2020-10-15T00:00:00Z": [-4, 0, 4],
       },
-      {
-        label: 'Winter',
-        ensembleMedian: 8,
-        range: { min: -2, max: 15, },
-      },
-    ]
+    }
   },
 
-  {
-    variable: {
-      label: 'Snowfall',
-      units: '%',
-      derived: true,
-    },
-    seasons: [
-      {
-        label: 'Winter',
-        ensembleMedian: -10,
-        range: { min: -17, max: 2, },
+  "prsn": {
+    "units": "%",
+    "percentiles": [10, 50, 90],
+    "region": "vancouver_island",
+    "climatology": 2020,
+    "variable": "pr",
+    "data": {
+      "annual": {
+        "2020-07-01T00:00:00Z": [-40, -5, 6]
       },
-      {
-        label: 'Spring',
-        ensembleMedian: -58,
-        range: { min: -71, max: -14, },
+      "seasonal":{
+        "2020-01-15T00:00:00Z": [-17, -10, 2],
+        "2020-04-15T00:00:00Z": [-71, -58, -14],
+        "2020-07-15T00:00:00Z": [0,0,0],
+        "2020-10-15T00:00:00Z": [-10, -2, 4],
       },
-    ]
+    }
   },
-
-  {
-    variable: {
-      label: 'Growing Degree Days',
-      units: 'degree days',
-      derived: true,
-    },
-    seasons: [
-      {
-        label: 'Annual',
-        ensembleMedian: 283,
-        range: { min: 179, max: 429, },
-      },
-    ]
-  },
-
-  {
-    variable: {
-      label: 'Heating Degree Days',
-      units: 'degree days',
-      derived: true,
-    },
-    seasons: [
-      {
-        label: 'Annual',
-        ensembleMedian: -648,
-        range: { min: -952, max: -459, },
-      },
-    ]
-  },
-
-  {
-    variable: {
-      label: 'Frost-Free Days',
-      units: 'days',
-      derived: true,
-    },
-    seasons: [
-      {
-        label: 'Annual',
-        ensembleMedian: 20,
-        range: { min: 12, max: 29, },
-      },
-    ]
-  },
-]
+}

--- a/src/components/app-root/App/App.js
+++ b/src/components/app-root/App/App.js
@@ -133,6 +133,32 @@ export default class App extends Component {
                     <Summary
                       region={get('value', this.state.region)}
                       futureTimePeriod={futureTimePeriod}
+                      tableContents={[
+                        {
+                          variable: 'tasmean',
+                          seasons: ['annual']
+                        },
+                        {
+                          variable: 'pr',
+                          seasons: ['annual', 'summer', 'winter']
+                        },
+                        {
+                          variable: 'prsn',
+                          seasons: ['winter', 'spring']
+                        },
+                        // {
+                        //   variable: 'gdd',
+                        //   seasons: ['annual']
+                        // },
+                        // {
+                        //   variable: 'hdd',
+                        //   seasons: ['annual']
+                        // },
+                        // {
+                        //   variable: 'fdETCCDI',
+                        //   seasons: ['annual']
+                        // },
+                      ]}
                     />
                     <T path='summary.notes.general' data={{
                       region: region,

--- a/src/components/app-root/App/App.js
+++ b/src/components/app-root/App/App.js
@@ -130,7 +130,10 @@ export default class App extends Component {
                     title={<T as='string' path='summary.tab'/>}
                     className='pt-2'
                   >
-                    <Summary summary={summary}/>
+                    <Summary
+                      region={get('value', this.state.region)}
+                      futureTimePeriod={futureTimePeriod}
+                    />
                     <T path='summary.notes.general' data={{
                       region: region,
                       futureDecade: middleDecade(futureTimePeriod),

--- a/src/components/app-root/App/App.js
+++ b/src/components/app-root/App/App.js
@@ -133,32 +133,7 @@ export default class App extends Component {
                     <Summary
                       region={get('value', this.state.region)}
                       futureTimePeriod={futureTimePeriod}
-                      tableContents={[
-                        {
-                          variable: 'tasmean',
-                          seasons: ['annual']
-                        },
-                        {
-                          variable: 'pr',
-                          seasons: ['annual', 'summer', 'winter']
-                        },
-                        {
-                          variable: 'prsn',
-                          seasons: ['winter', 'spring']
-                        },
-                        // {
-                        //   variable: 'gdd',
-                        //   seasons: ['annual']
-                        // },
-                        // {
-                        //   variable: 'hdd',
-                        //   seasons: ['annual']
-                        // },
-                        // {
-                        //   variable: 'fdETCCDI',
-                        //   seasons: ['annual']
-                        // },
-                      ]}
+                      tableContents={T.get(texts, 'summary.table.contents')}
                     />
                     <T path='summary.notes.general' data={{
                       region: region,

--- a/src/components/data-displays/Summary/Summary.js
+++ b/src/components/data-displays/Summary/Summary.js
@@ -52,49 +52,74 @@ class Summary extends React.Component {
   //
   // This component is wrapped with `withAsyncData` to inject the summary
   // statistics that are fetched asynchronously, according to the
-  // selected region and climatological time period
-  //
-  // The summary statistics, represented by the prop `summary`, are encoded
-  // in the following format. This is actually a specifier for the table
-  // rows rather than raw data from the backend. The data loader is
-  // (at present) responsible for making the transformation from raw data to
-  // row specifiers, using the value of `tableContents` to drive it.
-  //
-  // [
-  //   {
-  //     variable: {
-  //       label: 'Precipitation',
-  //       units: '%',
-  //     },
-  //     seasons: [
-  //       {
-  //         label: 'Annual',
-  //         ensembleMedian: 6,
-  //         range: { min: 2, max: 12, },
-  //       },
-  //       {
-  //         label: 'Summer',
-  //         ensembleMedian: -1,
-  //         range: { min: -8, max: 6, },
-  //       },
-  //       {
-  //         label: 'Winter',
-  //         ensembleMedian: 8,
-  //         range: { min: -2, max: 15, },
-  //       },
-  //       ...
-  //     ]
-  //   },
-  //   ...
-  // ]
-
+  // selected region and climatological time period.
 
   static propTypes = {
     region: PropTypes.object.isRequired,
     futureTimePeriod: PropTypes.object.isRequired,
-    summary: PropTypes.array,
     baseline: PropTypes.object,
+
     tableContents: PropTypes.array.isRequired,
+    // Abstract specification of the summary table. Data is implicit in the
+    // variable and season specifications, and is fetched by the data loader
+    // to construct the concrete table specification. Rows are specified
+    // in order of display, "depth first" by variable then seasons.
+    //
+    // Example value of this prop:
+    //
+    // [
+    //   { variable: 'tasmean', seasons: ['annual'] },
+    //   { variable: 'pr', seasons: ['annual', 'summer', 'winter'] },
+    // ]
+
+    summary: PropTypes.array,
+    // Concrete specification of the summary table, explicitly including data
+    // fetched from the backend and some labelling. This is a holdover from
+    // an earlier, highly convenient format used when there was no backend
+    // API at all. It has however proved a good design to separate the abstract
+    // spec (`tableContents`) from the concrete one. It is not a perfect way
+    // to handle this (see TO-DO below), but it is quite usable.
+    //
+    // Table rows are specified in order of display, "depth first" by
+    // variable then seasons.
+    //
+    // Note: This prop is injected via `withAsyncData`. Users should not be
+    // specifying this prop directly, only `tableContents`.
+    //
+    // The data loader is (at present) responsible for making the transformation
+    // from backend data to these row specifiers, using the value of
+    // `tableContents` to direct it.
+    //
+    // Example value of this prop:
+    //
+    // [
+    //   {
+    //     variable: {
+    //       label: 'Precipitation',
+    //       units: '%',
+    //     },
+    //     seasons: [
+    //       {
+    //         label: 'Annual',
+    //         ensembleMedian: 6,
+    //         range: { min: 2, max: 12, },
+    //       },
+    //       {
+    //         label: 'Summer',
+    //         ensembleMedian: -1,
+    //         range: { min: -8, max: 6, },
+    //       },
+    //       {
+    //         label: 'Winter',
+    //         ensembleMedian: 8,
+    //         range: { min: -2, max: 15, },
+    //       },
+    //       ...
+    //     ]
+    //   },
+    //   ...
+    // ]
+
   };
 
   static defaultProps = {
@@ -162,6 +187,11 @@ class Summary extends React.Component {
 // format that Summary consumes. It's a bit tedious, but Summary already
 // works with hardcoded data in this format, and something very like this
 // would have to be done in any case. Let's reduce to an already solved problem!
+
+// TODO: This idea turned out to have strengths. It would be even better to
+//  eliminate `toVariableLabel` by placing this information in the
+//  `summary.table.contents` data structure. This will likely include a somewhat
+//  more general refactoring of what external text content drives Summary.
 
 
 // There's a better way to do this with the Variable selector options, but

--- a/src/data-services/rules-engine.js
+++ b/src/data-services/rules-engine.js
@@ -1,23 +1,8 @@
 import axios from 'axios';
 import urljoin from 'url-join';
 import mapKeys from 'lodash/fp/mapKeys';
+import { regionId } from '../utils/regions';
 import { middleDecade } from '../utils/time-periods';
-
-
-const regionId = region => {
-  // Map frontend region specifier to region id used by the backend.
-  const name = region.properties.english_na;
-  switch (name) {
-    case 'British Columbia': return 'bc';
-    case 'Mount Waddington': return 'mt_waddington';
-    default: return name.toLowerCase().replace(/\W+/g, '_');
-  }
-};
-
-
-const timePeriodId = middleDecade;
-  // Map frontend time period specifier to the time period id (middle decade)
-  // used by the backend.
 
 
 const normalizeRuleNames = mapKeys(key => key.substring(5));
@@ -35,7 +20,7 @@ export const fetchRulesResults = (region, timePeriod) => {
   return axios.get(
     urljoin(
       process.env.REACT_APP_RULES_ENGINE_URL,
-      `${regionId(region)}_${timePeriodId(timePeriod)}.json`
+      `${regionId(region)}_${middleDecade(timePeriod)}.json`
     )
   )
   .then(response => response.data)

--- a/src/data-services/summary-stats.js
+++ b/src/data-services/summary-stats.js
@@ -1,0 +1,35 @@
+import axios from 'axios';
+import mapKeys from 'lodash/fp/mapKeys';
+import { regionId } from '../utils/regions';
+import { middleDecade } from '../utils/time-periods';
+import summary from '../assets/summary';
+
+
+export const fetchSummaryStatistics = (
+  region, timePeriod, variable, percentiles
+) => {
+  // Fetch the summary statistics for the given region, climatological time
+  // period, variable, percentiles.
+  // `region` is a feature object from the regions service
+  // `timePeriod` is an object of the form {start_date, end_date}
+  // `variable` is a string identifying the variable (e.g., 'tasmean')
+  // `percentiles` is an array of percentile values to be computed across
+  //    the ensemble
+  // Returns
+
+  console.log('### fetchSummaryStatistics', region, timePeriod, variable, percentiles)
+  return Promise.resolve(summary[variable]);
+
+  return axios.get(
+    process.env.REACT_APP_SUMMARY_STATISTICS_URL,
+    {
+      params: {
+        region: regionId(region),
+        climatology: middleDecade(timePeriod),
+        variable,
+        percentiles: ','.join(percentiles)
+      }
+    }
+  )
+  .then(response => response.data);
+};

--- a/src/data-services/summary-stats.js
+++ b/src/data-services/summary-stats.js
@@ -1,8 +1,8 @@
 import axios from 'axios';
-import mapKeys from 'lodash/fp/mapKeys';
+import urljoin from 'url-join';
 import { regionId } from '../utils/regions';
 import { middleDecade } from '../utils/time-periods';
-import summary from '../assets/summary';
+import fake from '../assets/summary';
 
 
 export const fetchSummaryStatistics = (
@@ -18,10 +18,15 @@ export const fetchSummaryStatistics = (
   // Returns
 
   console.log('### fetchSummaryStatistics', region, timePeriod, variable, percentiles)
-  return Promise.resolve(summary[variable]);
 
+  // TODO: Remove fakery when backend available
+  if (process.env.REACT_APP_SUMMARY_STATISTICS_URL === 'fake') {
+    return Promise.resolve(fake[variable]);
+  }
   return axios.get(
-    process.env.REACT_APP_SUMMARY_STATISTICS_URL,
+    urljoin(process.env.REACT_APP_SUMMARY_STATISTICS_URL, 'tbd'),
+    // TODO: Replace with this when certain
+    // urljoin(process.env.REACT_APP_CE_BACKEND_URL, 'tbd'),
     {
       params: {
         region: regionId(region),

--- a/src/data-services/summary-stats.js
+++ b/src/data-services/summary-stats.js
@@ -15,7 +15,7 @@ export const fetchSummaryStatistics = (
   // `variable` is a string identifying the variable (e.g., 'tasmean')
   // `percentiles` is an array of percentile values to be computed across
   //    the ensemble
-  // Returns
+  // Returns a promise for the summary statistics data.
 
   console.log('### fetchSummaryStatistics', region, timePeriod, variable, percentiles)
 

--- a/src/utils/regions.js
+++ b/src/utils/regions.js
@@ -1,0 +1,11 @@
+export const regionId = region => {
+  // Map frontend region specifier to region id used by the backend.
+  const name = region.properties.english_na;
+  switch (name) {
+    case 'British Columbia': return 'bc';
+    case 'Mount Waddington': return 'mt_waddington';
+    default: return name.toLowerCase().replace(/\W+/g, '_');
+  }
+};
+
+


### PR DESCRIPTION
This PR addresses most of #45, except that the backend isn't ready yet, so the summary stats data service responds with fake data for now. All is in readiness for the turnover to a real backend.

This PR also adds the ability to configure the content of the Summary tab data table from the external text file, which can actually deliver any arbitrary data rather than just text.