### PR TITLE
Configure map colour scales for new variables

### DIFF
--- a/public/external-text/default.yaml
+++ b/public/external-text/default.yaml
@@ -187,6 +187,43 @@ maps:
     title: "### Historical: ${$$.fragments.period}"
   projected:
     title: "### Projected: ${$$.fragments.period}"
+  displaySpec:
+    fallback:
+      palette: seq-Oranges
+      range:
+        min: -50
+        max: 50
+      ticks: [-50, 0, 50]
+    gdd:
+      palette: seq-Oranges
+      range:
+        min: 0
+        max: 4000
+      ticks: [0, 1000, 2000, 3000, 4000]
+    hdd:
+      palette: seq-Oranges
+      range:
+        min: 0
+        max: 10000
+      ticks: [0, 2000, 4000, 6000, 8000, 10000]
+    pr:
+      palette: seq-Greens
+      range:
+        min: 0
+        max: 20
+      ticks: [0, 5, 10, 15, 20]
+    tasmax:
+      palette: div-BuRd
+      range:
+        min: -30
+        max: 40
+      ticks: [-30, -20, -10, 0, 10, 20, 30, 40]
+    tasmin:
+      palette: div-BuRd
+      range:
+        min: -40
+        max: 30
+      ticks: [-40, -30, -20, -10, 0, 10, 20, 30]
 
 graph:
   tab: Graph

--- a/public/external-text/default.yaml
+++ b/public/external-text/default.yaml
@@ -190,6 +190,8 @@ maps:
   displaySpec:
     fallback:
       palette: seq-Oranges
+      aboveMaxColor: black
+      belowMinColor: black
       range:
         min: -50
         max: 50

--- a/public/external-text/default.yaml
+++ b/public/external-text/default.yaml
@@ -215,15 +215,15 @@ maps:
     tasmax:
       palette: div-BuRd
       range:
-        min: -30
+        min: -40
         max: 40
-      ticks: [-30, -20, -10, 0, 10, 20, 30, 40]
+      ticks: [-40, -30, -20, -10, 0, 10, 20, 30, 40]
     tasmin:
       palette: div-BuRd
       range:
         min: -40
-        max: 30
-      ticks: [-40, -30, -20, -10, 0, 10, 20, 30]
+        max: 40
+      ticks: [-40, -30, -20, -10, 0, 10, 20, 30, 40]
 
 graph:
   tab: Graph

--- a/src/components/app-root/App/App.js
+++ b/src/components/app-root/App/App.js
@@ -13,7 +13,7 @@ import { fetchSummaryMetadata } from '../../../data-services/metadata';
 import summary from '../../../assets/summary';
 import rulebase from '../../../assets/rulebase';
 
-import T, { ExternalTextContext } from 'pcic-react-external-text';
+import T, { ExternalTextContext } from '../../../temporary/external-text';
 import AppHeader from '../AppHeader';
 
 import RegionSelector from '../../selectors/RegionSelector/RegionSelector';

--- a/src/components/data-displays/Summary/Summary.js
+++ b/src/components/data-displays/Summary/Summary.js
@@ -8,7 +8,7 @@ import keys from 'lodash/fp/keys';
 import map from 'lodash/fp/map';
 import zip from 'lodash/fp/zip';
 import tap from 'lodash/fp/tap';
-import T from 'pcic-react-external-text';
+import T from '../../../temporary/external-text';
 import withAsyncData from '../../../HOCs/withAsyncData';
 import { fetchSummaryStatistics } from '../../../data-services/summary-stats';
 import isEqual from 'lodash/fp/isEqual';

--- a/src/components/data-displays/impacts/Rules/Rules.js
+++ b/src/components/data-displays/impacts/Rules/Rules.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import RulesTable from '../RulesTable';
-import T from 'pcic-react-external-text';
+import T from '../../../../temporary/external-text';
 import './Rules.css';
 
 

--- a/src/components/data-displays/impacts/RulesTable/RulesTable.js
+++ b/src/components/data-displays/impacts/RulesTable/RulesTable.js
@@ -4,7 +4,7 @@ import { Table } from 'react-bootstrap';
 import { map } from 'lodash/fp';
 import ReactMarkdown from 'react-markdown';
 import classnames from 'classnames';
-import T from 'pcic-react-external-text';
+import T from '../../../../temporary/external-text';
 import './RulesTable.css';
 import Button from 'react-bootstrap/Button';
 

--- a/src/components/maps/ClimateLayer/ClimateLayer.js
+++ b/src/components/maps/ClimateLayer/ClimateLayer.js
@@ -6,6 +6,8 @@ import { wmsClimateLayerProps } from '../map-utils';
 
 
 export default class ClimateLayer extends React.Component {
+  static contextType = T.contextType;
+
   static propTypes = {
     fileMetadata: PropTypes.object,
     variableSpec: PropTypes.object,
@@ -13,11 +15,13 @@ export default class ClimateLayer extends React.Component {
   };
 
   render() {
+    const displaySpec = T.get(this.context, 'maps.displaySpec', {}, 'raw');
     return (
       <WMSTileLayer
         url={process.env.REACT_APP_NCWMS_URL}
         {...wmsClimateLayerProps(
           this.props.fileMetadata,
+          displaySpec,
           this.props.variableSpec,
           this.props.season
         )}

--- a/src/components/maps/ClimateLayer/ClimateLayer.js
+++ b/src/components/maps/ClimateLayer/ClimateLayer.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { WMSTileLayer } from 'react-leaflet';
+import T from '../../../temporary/external-text';
 import { wmsClimateLayerProps } from '../map-utils';
 
 

--- a/src/components/maps/NcwmsColourbar/NcwmsColourbar.js
+++ b/src/components/maps/NcwmsColourbar/NcwmsColourbar.js
@@ -35,7 +35,7 @@ import {
 } from '../map-utils';
 
 
-const getColorbarURI = (variableSpec, width, height) =>
+const getColorbarURI = (displaySpec, variableSpec, width, height) =>
   makeURI(
     process.env.REACT_APP_NCWMS_URL,
     {
@@ -49,6 +49,8 @@ const getColorbarURI = (variableSpec, width, height) =>
   );
 
 export default class NcwmsColourbar extends React.Component {
+  static contextType = T.contextType;
+
   static propTypes = {
     variableSpec: PropTypes.object,
     width: PropTypes.number,
@@ -61,9 +63,10 @@ export default class NcwmsColourbar extends React.Component {
   };
 
   render() {
-    const range = wmsDataRange(this.props.variableSpec);
+    const displaySpec = T.get(this.context, 'maps.displaySpec', {}, 'raw');
+    const range = wmsDataRange(displaySpec, this.props.variableSpec);
     const span = range.max - range.min;
-    const ticks = wmsTicks(this.props.variableSpec);
+    const ticks = wmsTicks(displaySpec, this.props.variableSpec);
     return (
       <div
           className={styles.wrapper}

--- a/src/components/maps/NcwmsColourbar/NcwmsColourbar.js
+++ b/src/components/maps/NcwmsColourbar/NcwmsColourbar.js
@@ -25,6 +25,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import map from 'lodash/fp/map';
+import T from '../../../temporary/external-text';
 import styles from './NcwmsColourbar.module.css';
 import { makeURI } from '../../../utils/uri';
 import {
@@ -42,7 +43,7 @@ const getColorbarURI = (variableSpec, width, height) =>
       colorbaronly: 'true',
       width,
       height,
-      palette: wmsPalette(variableSpec),
+      palette: wmsPalette(displaySpec, variableSpec),
       numcolorbands: wmsNumcolorbands,
     }
   );
@@ -75,6 +76,7 @@ export default class NcwmsColourbar extends React.Component {
               'margin-left': -this.props.width,
             }}
             src={getColorbarURI(
+              displaySpec,
               this.props.variableSpec,
               this.props.width,
               this.props.height

--- a/src/components/maps/TwoDataMaps/TwoDataMaps.js
+++ b/src/components/maps/TwoDataMaps/TwoDataMaps.js
@@ -27,7 +27,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Row, Col } from 'react-bootstrap';
-import T from 'pcic-react-external-text';
+import T from '../../../temporary/external-text';
 import DataMap from '../../maps/DataMap';
 import BCBaseMap from '../BCBaseMap';
 import NcwmsColourbar from '../NcwmsColourbar';

--- a/src/components/maps/map-utils.js
+++ b/src/components/maps/map-utils.js
@@ -37,6 +37,8 @@ export const getDisplaySpecItem = curry(
 export const wmsPalette = getDisplaySpecItem('palette');
 export const wmsDataRange = getDisplaySpecItem('range');
 export const wmsTicks = getDisplaySpecItem('ticks');
+export const wmsAboveMaxColor = getDisplaySpecItem('aboveMaxColor');
+export const wmsBelowMinColor = getDisplaySpecItem('belowMinColor');
 
 export const wmsStyle = (displaySpec, variableSpec) =>
   `default-scalar/${wmsPalette(displaySpec, variableSpec)}`;
@@ -58,8 +60,8 @@ export const wmsClimateLayerProps = (fileMetadata, displaySpec, variableSpec, se
     // srs: "EPSG:3005",
     transparent: true,
     version: '1.1.1',
-    abovemaxcolor: 'black',
-    belowmincolor: 'black',
+    abovemaxcolor: wmsAboveMaxColor(displaySpec, variableSpec),
+    belowmincolor: wmsBelowMinColor(displaySpec, variableSpec),
     layers: wmsLayerName(fileMetadata, variableSpec),
     time: wmsTime(fileMetadata, season),
     styles: wmsStyle(displaySpec, variableSpec),

--- a/src/components/maps/map-utils.js
+++ b/src/components/maps/map-utils.js
@@ -1,4 +1,4 @@
-import flow from 'lodash/fp/flow';
+import curry from 'lodash/fp/curry';
 import getOr from 'lodash/fp/getOr';
 import map from 'lodash/fp/map';
 import range from 'lodash/fp/range';
@@ -24,62 +24,31 @@ export const wmsTime = (fileMetadata, season) => {
 };
 
 
-// TODO: Style and range should be part of config. But the configs
-//  are getting a bit more structured than env variables will accommodate.
+export const getDisplaySpecItem = curry(
+  // Extract the relevant item (e.g., 'palette') from a display spec, which
+  // is a configuration object retrieved from the external text file.
+  (item, displaySpec, variableSpec) => getOr(
+      displaySpec.fallback[item],
+      [variableSpec.variable_id, item],
+      displaySpec
+    )
+);
 
-const variableId2WmsPalette = {
-  pr: 'seq-Greens',
-  tasmax: 'div-BuRd',
-  tasmin: 'div-BuRd',
-  fallback: 'seq-Oranges',
-};
-export const wmsPalette = variableSpec =>
-  getOr(
-    variableId2WmsPalette.fallback,
-    variableSpec.variable_id,
-    variableId2WmsPalette
-  );
+export const wmsPalette = getDisplaySpecItem('palette');
+export const wmsDataRange = getDisplaySpecItem('range');
+export const wmsTicks = getDisplaySpecItem('ticks');
 
-
-export const wmsStyle = variableSpec =>
-  `default-scalar/${wmsPalette(variableSpec)}`;
+export const wmsStyle = (displaySpec, variableSpec) =>
+  `default-scalar/${wmsPalette(displaySpec, variableSpec)}`;
 
 
-const variableId2DataRange = {
-  pr: { min: 0, max: 20 },
-  tasmax: { min: -30, max: 40 },
-  tasmin: { min: -40, max: 30 },
-  fallback: { min: -40, max: 50 },
-};
-export const wmsDataRange = variableSpec =>
-  getOr(
-    variableId2DataRange.fallback,
-    variableSpec.variable_id,
-    variableId2DataRange
-  );
-
-
-const variableId2Ticks = {
-  pr: [0, 5, 10, 15, 20],
-  tasmax: [-30, -20, -10, 0, 10, 20, 30, 40],
-  tasmin: [-40, -30, -20, -10, 0, 10, 20, 30],
-  fallback: [0, 10],
-};
-export const wmsTicks = variableSpec =>
-  getOr(
-    variableId2Ticks.fallback,
-    variableSpec.variable_id,
-    variableId2Ticks
-  );
-
-
-export const wmsColorScaleRange = variableSpec => {
-  const range = wmsDataRange(variableSpec);
+export const wmsColorScaleRange = (displaySpec, variableSpec) => {
+  const range = wmsDataRange(displaySpec, variableSpec);
   return `${range.min},${range.max}`
 };
 
 
-export const wmsClimateLayerProps = (fileMetadata, variableSpec, season) => {
+export const wmsClimateLayerProps = (fileMetadata, displaySpec, variableSpec, season) => {
   return {
     format: 'image/png',
     logscale: false,
@@ -93,9 +62,7 @@ export const wmsClimateLayerProps = (fileMetadata, variableSpec, season) => {
     belowmincolor: 'black',
     layers: wmsLayerName(fileMetadata, variableSpec),
     time: wmsTime(fileMetadata, season),
-    styles: wmsStyle(variableSpec),
-    colorscalerange: wmsColorScaleRange(variableSpec),
+    styles: wmsStyle(displaySpec, variableSpec),
+    colorscalerange: wmsColorScaleRange(displaySpec, variableSpec),
   }
 };
-
-

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom';
 import './index.css';
 import App from './components/app-root/App';
 import * as serviceWorker from './serviceWorker';
-import ExternalText from 'pcic-react-external-text';
+import ExternalText from './temporary/external-text';
 import { makeYamlLoader } from './utils/external-text';
 
 console.log('index.js: App', App)

--- a/src/temporary/external-text.js
+++ b/src/temporary/external-text.js
@@ -1,0 +1,203 @@
+// TODO: Integrate this minor change (in fn `get`) into pcic-react-external-text
+//  and replace usage of this module with that package again. This module is a
+//  temporary expedient for fast dev.
+
+import PropTypes from 'prop-types';
+import React from 'react';
+import ReactMarkdown from 'react-markdown';
+import _ from 'lodash';
+import addMapDeep from 'deepdash/addMapDeep';
+
+addMapDeep(_);
+
+
+export const ExternalTextContext = React.createContext(
+  null
+);
+
+
+export class Provider extends React.Component {
+  // Data provider for component `ExternalText`, which accesses this data
+  // via the React context API.
+  //
+  // This component performs two tasks:
+  // - loads the source data into this component's state
+  // - wraps its children in a React context provider whose value is set
+  //   from the source data
+
+  static propTypes = {
+    defaultTexts: PropTypes.object,
+    // Default, non-asynchronous data source.
+
+    loadTexts: PropTypes.func,
+    // Callback for loading data asynchronously.
+  };
+
+  state = {
+    texts: null,
+  };
+
+  setTexts = texts => {
+    this.setState({ texts });
+  };
+
+  componentDidMount() {
+    this.setTexts(this.props.defaultTexts);
+    if (this.props.loadTexts) {
+      this.props.loadTexts(this.setTexts);
+    }
+  }
+
+  render() {
+    return (
+      <ExternalTextContext.Provider value={this.state.texts}>
+        {this.props.children}
+      </ExternalTextContext.Provider>
+    );
+  }
+}
+
+
+// Backticks must be escaped during processing, then unescaped when the
+// final string is returned. This is because backtick (which incidentally
+// is also important in Markdown) delimits template strings, and template
+// strings are the core of the evaluator. Hence `escape` and `unescape`.
+// Does not escape an already escaped backtick.
+
+export const escape = s => (
+  _.map(s, (c, i, t) => (c !== '`' || (i > 0 && t[i-1] === `\\`)) ? c : '\\`')
+).join('');
+// This negative lookbehind formulation is tighter, but it lookbehind isn't
+// supported (yet) in many browsers. It does work in Node.js and Chrome.
+// export const escape = s => s.replace(/(?<!\\)`/g, '\\`');
+
+// And the inverse.
+export const unescape = s => s.replace(/\\`/g, '`');
+
+
+export function evaluateAsTemplateLiteral(s, context = {}) {
+  // Convert string `s` to a template literal and evaluate it in a context
+  // where all the properties of object `context` are available as identifiers
+  // at the top level. (E.g., if `context = { 'a': 1, 'b': 2 }`, then
+  // the template literal can refer to `context.a` and `context.b`
+  // as `${a}` and `${b}`, respectively.)
+
+  // `evaluator` constructs a function that evaluates a template string
+  // constructed from the ordinary string passed in (by enclosing it in
+  // backticks). The argument(s) of the returned evaluator are the context
+  // values.
+  const makeEvaluator = s =>
+    new Function(...Object.keys(context), 'return `' + s + '`');
+
+  // `reevaluate` recursively makes and invokes an evaluator for the string.
+  // A different string, containing further interpolations (`${...}`), may
+  // result from interpolation of other strings into the evaluated string.
+  // `reevaluate` stops reevaluating when two successive evaluations return
+  // the same string. It also applies backtick escaping at each new evaluation,
+  // for the same reason.
+  const reevaluate = (prev, curr) => {
+    const e = escape(curr);
+    return prev === e ?
+      e :
+      reevaluate(e, makeEvaluator(e)(...Object.values(context)))
+  };
+
+  // It's important that `Object.keys(x)` and `Object.values(x)` are guaranteed
+  // to return their results in the same order for any given `x`. That order
+  // is arbitrary, but it is shared between them.
+
+  // Kick off the evaluation(s), and strip escaping after all is done.
+  return unescape(reevaluate('', s));
+}
+
+
+export function get(texts, path, data = {}, as = 'string') {
+  // This is the core of `ExternalText`.
+  //
+  // It gets the object selected by `path` from `texts` and maps
+  // the function of (optionally) evaluation and rendering as Markdown
+  // over all strings in the object's leaf (non-object) members.
+  //
+  // Argument `as` controls what function (identity, evaluation as a template
+  // literal, or evaluation and rendering as Markdown) is applied to each
+  // leaf member. The values 'raw', 'string', and 'markdown', respectively,
+  // correspond to these mappings.
+  //
+  // Component `ExternalText` simply invokes this function on its context
+  // and props. The simplest case is when `path` selects a single string
+  // and it returns a single rendered React element.
+  //
+  // This function is exposed as a static so that more complicated use can
+  // be made of it. This should be done only if there is no simpler way to
+  // do it using <ExternalText/> elements. For example, if `'path.to.array'`
+  // selects an array of items from `texts`, then prefer this
+  //
+  // ```
+  //  <div>
+  //    <ExternalText path='path.to.array' />
+  //  </div>
+  // ```
+  //
+  // over this equivalent but unnecessarily complicated code
+  //
+  // ```
+  //  <div>
+  //    { ExternalText.get(this.context, 'path.to.array') }
+  //  </div>
+  // ```
+
+  const item = (texts && _.get(texts, path)) || `{{${path}}}`;
+
+  const render = value => {
+    if (as === 'raw') {
+      return value;
+    }
+    const source = evaluateAsTemplateLiteral(
+      _.toString(value),
+      { $$: texts, ...data }
+    );
+    if (as === 'string') {
+      return source;
+    }
+    return (<ReactMarkdown escapeHtml={false} source={source}/>);
+  };
+
+  return _.mapDeep(item, render, { leavesOnly: true });
+}
+
+
+export default class ExternalText extends React.Component {
+  // Core component of external texts module.
+  //
+  // This component renders an external text (source texts provided through
+  // the React context API via `ExternalText.Provider`) selected by `path`,
+  // using the data context `data` and rendered according to `as`.
+  // See static function `get` for more details.
+  //
+  // Supporting components and functions are both exported by the module
+  // and added as properties of `ExternalText`.
+
+  static propTypes = {
+    path: PropTypes.string,
+    // Path (JS standard notation) selecting text item from source texts.
+    data: PropTypes.object,
+    // Data context in which to evaluate item's text.
+    as: PropTypes.oneOf(['raw', 'string', 'markdown']),
+    // How to render the item's text.
+  };
+
+  static defaultProps = {
+    as: 'markdown',
+  };
+
+  render() {
+    const texts = this.context;
+    const { path, data, as } = this.props;
+    return get(texts, path, data, as);
+  }
+}
+
+ExternalText.contextType = ExternalTextContext;
+ExternalText.Provider = Provider;
+ExternalText.get = get;
+ExternalText.Markdown = ReactMarkdown;


### PR DESCRIPTION
This PR enables us to configure the display parameters for the maps via the external text file (which now needs a new name, since it is not just text, but that's another matter). For each variable, identified by its variable id (e.g. 'pr'), the following values can be configured:
- palette
- range (min, max value expected)
- ticks (values where ticks should be placed on the colour bar)

Notes:
- All values (palette, range) and the colour bar are _purposefully common_ to the two maps, so that the maps are comparable by eye. Maps with independent colour scales are (imho) impossible to compare visually.
- Because these values are in the external text file, they can be updated on the fly to account for new data (e.g., to correct an error, or to account for an updated dataset with a different range). The values are found in the external text file under the key 'maps.displaySpec'.
- External texts now functions as a generic configuration file, not just a text resource, courtesy of a 3-line tweak to its code. To speed development, there is a local copy of this code. The code change will eventually be merged back into the pcic-react-external-texts package and the local copy removed.

Resolves #59