### PR TITLE
Fetch metadata for multiple models

### DIFF
--- a/.env
+++ b/.env
@@ -3,10 +3,9 @@ REACT_APP_TILECACHE_URL=https://b.tile.pacificclimate.org/tilecache/tilecache.py
 REACT_APP_NCWMS_URL=https://services.pacificclimate.org/pcex/ncwms
 REACT_APP_REGIONS_SERVICE_URL=https://services.pacificclimate.org/plan2adapt/regions/ows
 REACT_APP_RULES_ENGINE_URL=https://services.pacificclimate.org/plan2adapt/impacts
-REACT_APP_ENSEMBLE_NAME=p2a_files
-#REACT_APP_ENSEMBLE_NAME=p2a_classic
-REACT_APP_MODEL_ID=PCIC12
-REACT_APP_EMISSIONS_SCENARIOS=historical,rcp85;historical, rcp85
+#REACT_APP_ENSEMBLE_NAME=p2a_files
+#REACT_APP_MODEL_ID=PCIC12
+REACT_APP_ENSEMBLE_NAME=p2a_classic
+REACT_APP_MODEL_ID=PCIC12;anusplin
+REACT_APP_EMISSIONS_SCENARIOS=historical,rcp85;historical, rcp85;historical
 REACT_APP_EXTERNAL_TEXT=external-text/default.yaml
-
-

--- a/public/external-text/default.yaml
+++ b/public/external-text/default.yaml
@@ -217,12 +217,12 @@ maps:
         min: -50
         max: 50
       ticks: [-50, 0, 50]
-    fdd:
+    ffd:
       palette: x-Occam
       range:
         min: 0
-        max: 4000
-      ticks: [0, 1000, 2000, 3000, 4000]
+        max: 366
+      ticks: [0, 100, 200, 300, 365]
     gdd:
       palette: x-Occam
       range:

--- a/src/components/maps/DataMap/DataMap.js
+++ b/src/components/maps/DataMap/DataMap.js
@@ -152,7 +152,6 @@ class DataMapDisplay extends React.Component {
 // down to a single item that is the metadata for the layer to be displayed
 // in DataMap.
 const metadataFilter = props => {
-  console.log('### metadataFilter: props', props)
   const criteria = {
     // start_date, end_date
     ...mapValues(v => v.toString())(props.timePeriod),
@@ -162,7 +161,6 @@ const metadataFilter = props => {
     // is very well suited to our purposes here.
     timescale: props.season === 16 ? 'yearly' : 'seasonal',
   };
-  console.log('### metadataFilter: criteria', criteria)
   return filter(criteria)
 };
 
@@ -171,17 +169,11 @@ const metadataFilter = props => {
 // `DataMapDisplay` for the given props.
 const loadFileMetadata = props => {
   return flow(
-    tap(x => console.log('### loadFileMetadata: metadata', x)),
     metadataFilter(props),
-    tap(x => console.log('### loadFileMetadata: filtered', x)),
     metadata => {
-      console.log('### loadFileMetadata: next', metadata)
-      console.log('### loadFileMetadata: next', metadata.length)
       // TODO: Don't throw an error when metadata matching fails. Instead,
       //   show an error message in the map.
       if (metadata.length === 0) {
-        console.log('### loadFileMetadata: fuck: props', props)
-        console.log('### loadFileMetadata: fuck: props', metadata)
         throw new Error('No matching metadata');
       }
       if (metadata.length > 1) {

--- a/src/components/maps/DataMap/DataMap.js
+++ b/src/components/maps/DataMap/DataMap.js
@@ -7,6 +7,7 @@ import isEqual from 'lodash/fp/isEqual';
 import flow from 'lodash/fp/flow';
 import filter from 'lodash/fp/filter';
 import mapValues from 'lodash/fp/mapValues';
+import tap from 'lodash/fp/tap';
 
 import { BCBaseMap } from 'pcic-react-leaflet-components';
 import CanadaBaseMap from '../CanadaBaseMap';
@@ -151,6 +152,7 @@ class DataMapDisplay extends React.Component {
 // down to a single item that is the metadata for the layer to be displayed
 // in DataMap.
 const metadataFilter = props => {
+  console.log('### metadataFilter: props', props)
   const criteria = {
     // start_date, end_date
     ...mapValues(v => v.toString())(props.timePeriod),
@@ -160,6 +162,7 @@ const metadataFilter = props => {
     // is very well suited to our purposes here.
     timescale: props.season === 16 ? 'yearly' : 'seasonal',
   };
+  console.log('### metadataFilter: criteria', criteria)
   return filter(criteria)
 };
 
@@ -168,11 +171,17 @@ const metadataFilter = props => {
 // `DataMapDisplay` for the given props.
 const loadFileMetadata = props => {
   return flow(
+    tap(x => console.log('### loadFileMetadata: metadata', x)),
     metadataFilter(props),
+    tap(x => console.log('### loadFileMetadata: filtered', x)),
     metadata => {
+      console.log('### loadFileMetadata: next', metadata)
+      console.log('### loadFileMetadata: next', metadata.length)
       // TODO: Don't throw an error when metadata matching fails. Instead,
       //   show an error message in the map.
       if (metadata.length === 0) {
+        console.log('### loadFileMetadata: fuck: props', props)
+        console.log('### loadFileMetadata: fuck: props', metadata)
         throw new Error('No matching metadata');
       }
       if (metadata.length > 1) {

--- a/src/data-services/metadata.js
+++ b/src/data-services/metadata.js
@@ -79,16 +79,10 @@ export function fetchSummaryMetadata() {
   console.log('### fetchSummaryMetadata: models', models)
   return flow(
     map(fetchSummaryMetadataForModel),
-    tap(x => console.log('### fetchSummaryMetadata: promises', x)),
+    // tap(x => console.log('### fetchSummaryMetadata: promises', x)),
     // Why can't I just say `Promise.all` here?? Goddamn it.
-    promises => {
-      return Promise.all(promises)
-    },
-    promise => {
-      console.log('### fetchSummaryMetadata: promise (all)', promise)
-      // Concatenate all the metadata sets into one.
-      return promise.then(flatten)
-    },
+    promises => Promise.all(promises),
+    promise => promise.then(flatten),
   )(models);
 }
 


### PR DESCRIPTION
This PR:
- Extends the `REACT_APP_MODEL_ID` env variable to allow for multiple models, separated by semicolons. Default now = `PCIC12;anusplin`.
- It also adds a third item to the default value for `REACT_APP_EMISSIONS_SCENARIOS`: Now = `historical,rcp85;historical, rcp85;historical`

Resolves #78 
