### PR TITLE
Units conversions

### DIFF
--- a/public/external-text/default.yaml
+++ b/public/external-text/default.yaml
@@ -12,7 +12,7 @@ selectors:
     default: 2050
   variable:
     prefix: ... with details about
-    default: prsn
+    default: pr
   season:
     prefix: for a typical
     postfix: period
@@ -23,7 +23,7 @@ summary:
   tab: Summary
   title: "## Summary of Climate Change for ${region} in the ${futureTimePeriod}"
   # It's tempting to do this content as a Markdown table, but unfortunately
-  # MD doesn't# let you span table rows or columns.
+  # MD doesn't let you span table rows or columns.
   table:
     heading:
       variable: Climate Variable
@@ -46,22 +46,12 @@ summary:
         seasons:
           - annual
       - variable: pr
-        display: absolute
-        precision: 2
-        seasons:
-          - annual
-      - variable: pr
         display: relative
         precision: 2
         seasons:
           - annual
           - summer
           - winter
-      - variable: prsn
-        display: absolute
-        precision: 2
-        seasons:
-          - annual
       - variable: prsn
         display: relative
         precision: 2

--- a/public/external-text/default.yaml
+++ b/public/external-text/default.yaml
@@ -500,58 +500,70 @@ colourScale:
   label: ${label} (${units})
   note: '*Note: This colour scale applies to both maps.*'
 
-# TODO: remove 'units' key-val pairs; defunct
+# Application-wide information about variables and how they are to be treated.
+# Variables are identified by their short, science-y id.
+# The `type` key is used to locate the appropriate units conversion data
+# in the `units` config, below.
 variables:
   tasmean:
     label: Temperature
     derived: true
-    units: °C
-    displayUnits:
-      target: °C
-      conversions:
-        'degC': 1  # shorthand for the following
-        # 'degC':
-        #   scale: 1
-        #   offset: 0
-        'degF':
-          scale: .555
-          offset: -32
-
+    type: temperature
+    displayUnits: °C
   pr:
     label: Precipitation
-    units: mm/d
-    displayUnits:
-      target: mm/yr
-      conversions:
-        'kg m-2 d-1': 365
-        'mm/d': 365
+    type: precipitation flux
+    displayUnits: mm/yr
   prsn:
     label: Snowfall
     derived: true
-    units: ??
-    displayUnits:
-      target: mm/yr
-      conversions:
-        'kg m-2 d-1': 365
-        'mm/d': 365
+    type: snowfall flux
+    displayUnits: mm/yr
   gdd:
     label: Growing Degree-Days
     derived: true
-    units: degree days
-    displayUnits:
-      target: degree days
-      conversions:
+    type: temperature-time
+    displayUnits: degree days
   hdd:
     label: Heating Degree-Days
     derived: true
-    units: degree days
-    displayUnits:
-      target: degree days
-      conversions:
+    type: temperature-time
+    displayUnits: degree days
   ffd:
     label: Frost-Free Days
     derived: true
-    units: days
-    displayUnits:
-      target: days
-      conversions:
+    type: time
+    displayUnits: days
+
+# Application-wide information about units of measure, mainly consisting of
+# data for computing conversions between units within a specific variable type.
+# Conversions are grouped by variable type, named by top-level key.
+# In each group, key-value pairs specify scale and offset (value) for
+# converting units (key) to nominal base units:
+#   baseValue = value * scale + offset
+# Scale and offset can be specified key-value pairs of those names or by a
+# single numerical value. If only a single numerical value is provided, it is
+# interpreted as scale, with implicit offset 0.
+# If a string is provided, it is interpreted as a synonym for the named unit.
+# Note the distinction between precipitation flux and snowfall flux: The
+# conversion from mass flux units to depth flux units differs.
+units:
+  'precipitation flux':   # variable type
+    'mm/yr': 1            # nominal base unit
+    'mm/d': 365           # another unit: scale: 365, offset: 0
+    'kg m-2 d-1': mm/d    # synonym
+  'snowfall flux':
+    'mm/yr': 1
+    'mm/d': 365
+    'kg m-2 d-1': 3650    # approximation that converts mass to snow depth
+  temperature:
+    degC: 1
+    '°C': degC
+    'degF':
+      scale: .55555555555555
+      offset: -17.7777777777778
+    '°F': degF
+  temperature-time:
+    'degree days': 1
+  time:
+    days: 1

--- a/public/external-text/default.yaml
+++ b/public/external-text/default.yaml
@@ -46,12 +46,22 @@ summary:
         seasons:
           - annual
       - variable: pr
+        display: absolute
+        precision: 2
+        seasons:
+          - annual
+      - variable: pr
         display: relative
         precision: 2
         seasons:
           - annual
           - summer
           - winter
+      - variable: prsn
+        display: absolute
+        precision: 2
+        seasons:
+          - annual
       - variable: prsn
         display: relative
         precision: 2
@@ -487,7 +497,7 @@ components:
     concentrations.
 
 colourScale:
-  label: ${variable} (${units})
+  label: ${label} (${units})
   note: '*Note: This colour scale applies to both maps.*'
 
 # TODO: remove 'units' key-val pairs; defunct
@@ -511,15 +521,19 @@ variables:
     label: Precipitation
     units: mm/d
     displayUnits:
-      target: mm/d
+      target: mm/yr
       conversions:
+        'kg m-2 d-1': 365
+        'mm/d': 365
   prsn:
     label: Snowfall
     derived: true
     units: ??
     displayUnits:
-      target: mm/d
+      target: mm/yr
       conversions:
+        'kg m-2 d-1': 365
+        'mm/d': 365
   gdd:
     label: Growing Degree-Days
     derived: true

--- a/public/external-text/default.yaml
+++ b/public/external-text/default.yaml
@@ -12,7 +12,7 @@ selectors:
     default: 2050
   variable:
     prefix: ... with details about
-    default: pr
+    default: prsn
   season:
     prefix: for a typical
     postfix: period
@@ -218,6 +218,8 @@ maps:
   projected:
     title: "#### Projected: ${$$.components.period}"
   displaySpec:
+    # Organized by variable.
+    # NB: range and tick values are in *display* units.
     fallback:
       palette: seq-Oranges
       logscale: false
@@ -249,16 +251,16 @@ maps:
       palette: seq-Greens
       logscale: true
       range:
-        min: 0.1
-        max: 20
-      ticks: [0.1, 0.2, 0.5, 1, 2, 5, 10, 20]
+        min: 10
+        max: 10000
+      ticks: [10, 100, 1000, 10000]
     prsn:
       palette: x-Occam
       logscale: true
       range:
-        min: 0.1
-        max: 20
-      ticks: [0.1, 0.2, 0.5, 1, 2, 5, 10, 20]
+        min: 10
+        max: 20000
+      ticks: [10, 100, 1000, 10000, 20000]
     tasmax:
       palette: x-Occam
       range:
@@ -504,36 +506,43 @@ colourScale:
 # Variables are identified by their short, science-y id.
 # The `type` key is used to locate the appropriate units conversion data
 # in the `units` config, below.
+# TODO: Remove `dataUnits` and supply from metadata.
 variables:
   tasmean:
     label: Temperature
     derived: true
     type: temperature
     displayUnits: °C
+    dataUnits: degC
   pr:
     label: Precipitation
     type: precipitation flux
     displayUnits: mm/yr
+    dataUnits: kg m-2 d-1
   prsn:
     label: Snowfall
     derived: true
     type: snowfall flux
     displayUnits: mm/yr
+    dataUnits: kg m-2 d-1
   gdd:
     label: Growing Degree-Days
     derived: true
     type: temperature-time
     displayUnits: degree days
+    dataUnits: degree days
   hdd:
     label: Heating Degree-Days
     derived: true
     type: temperature-time
     displayUnits: degree days
+    dataUnits: degree days
   ffd:
     label: Frost-Free Days
     derived: true
     type: time
     displayUnits: days
+    dataUnits: days
 
 # Application-wide information about units of measure, mainly consisting of
 # data for computing conversions between units within a specific variable type.

--- a/public/external-text/default.yaml
+++ b/public/external-text/default.yaml
@@ -34,7 +34,7 @@ summary:
     rows:
       variable: |
         ${variable.label}${variable.derived ? '*': ''} (${variable.units})
-      season: ${season.label} ((${season.units}))
+      season: ${season.label}
       ensembleMedian: ${format(season.percentiles[1])}${unitsSuffix(variable.units)}
       range: |
         ${format(season.percentiles[0])}${isLong(variable.units) ? '': unitsSuffix(variable.units)} to

--- a/public/external-text/default.yaml
+++ b/public/external-text/default.yaml
@@ -34,7 +34,7 @@ summary:
     rows:
       variable: |
         ${variable.label}${variable.derived ? '*': ''} (${variable.units})
-      season: ${season.label}
+      season: ${season.label} ((${season.units}))
       ensembleMedian: ${format(season.percentiles[1])}${unitsSuffix(variable.units)}
       range: |
         ${format(season.percentiles[0])}${isLong(variable.units) ? '': unitsSuffix(variable.units)} to
@@ -490,33 +490,54 @@ colourScale:
   label: ${variable} (${units})
   note: '*Note: This colour scale applies to both maps.*'
 
+# TODO: remove 'units' key-val pairs; defunct
 variables:
-  tasmax:
-    label: Maximum Temperature
-    units: °C
-  tasmin:
-    label: Minimum Temperature
-    units: °C
   tasmean:
     label: Temperature
     derived: true
     units: °C
+    displayUnits:
+      target: °C
+      conversions:
+        'degC': 1  # shorthand for the following
+        # 'degC':
+        #   scale: 1
+        #   offset: 0
+        'degF':
+          scale: .555
+          offset: -32
+
   pr:
     label: Precipitation
     units: mm/d
+    displayUnits:
+      target: mm/d
+      conversions:
   prsn:
     label: Snowfall
     derived: true
     units: ??
+    displayUnits:
+      target: mm/d
+      conversions:
   gdd:
     label: Growing Degree-Days
     derived: true
     units: degree days
+    displayUnits:
+      target: degree days
+      conversions:
   hdd:
     label: Heating Degree-Days
     derived: true
     units: degree days
+    displayUnits:
+      target: degree days
+      conversions:
   ffd:
     label: Frost-Free Days
     derived: true
     units: days
+    displayUnits:
+      target: days
+      conversions:

--- a/src/components/app-root/App/App.js
+++ b/src/components/app-root/App/App.js
@@ -154,6 +154,7 @@ export default class App extends Component {
                   futureTimePeriod={futureTimePeriod}
                   tableContents={getConfig('summary.table.contents')}
                   variableConfig={getConfig('variables')}
+                  unitsConversions={getConfig('units')}
                 />
                 <T path='summary.notes.derivedVars'/>
               </Tab>

--- a/src/components/data-displays/Summary/Summary.js
+++ b/src/components/data-displays/Summary/Summary.js
@@ -44,12 +44,12 @@ const getDisplayUnits = (variableConfig, variable, display) => {
 
 
 const convertToDisplayUnits = curry(
-  (displayUnits, value, units) => {
-    if (displayUnits.target === units) {
+  (displayUnits, baseUnits, value) => {
+    if (displayUnits.target === baseUnits) {
       return value;
     }
     try {
-      const conversion = displayUnits.conversions[units];
+      const conversion = displayUnits.conversions[baseUnits];
       const { scale, offset } = isNumber(conversion) ?
         { scale: conversion, offset: 0 } :
         conversion;
@@ -231,7 +231,7 @@ class Summary extends React.Component {
             const { variable, display, precision } = row;
             const displayUnits =
               getDisplayUnits(variableConfig, variable, display);
-            const convertData = convertToDisplayUnits(displayUnits);
+            const convertDataFrom = convertToDisplayUnits(displayUnits);
             const units = displayUnits.target;
             // const units = getUnits(variableConfig, variable, display);
             const variableData = {
@@ -246,16 +246,14 @@ class Summary extends React.Component {
               // In addition to the data items it might want (e.g.,
               // `variable.label`, we also include utility functions (e.g.,
               // `format`).
-              // TODO: Curry this better!
-              const displayPercentiles = map(
-                percentile => convertData(percentile, season.units)
-              )(season.percentiles);
+              const convertData = convertDataFrom(season.units);
+              const percentiles = map(convertData)(season.percentiles);
               const data = {
                 variable: variableData,
                 season: {
                   ...season,
                   label: capitalize(season.id),
-                  percentiles: displayPercentiles,
+                  percentiles,
                 },
                 format: displayFormat(precision),
                 isLong,

--- a/src/components/data-displays/Summary/Summary.js
+++ b/src/components/data-displays/Summary/Summary.js
@@ -142,7 +142,6 @@ class Summary extends React.Component {
   };
 
   render() {
-    console.log('### Summary: props', this.props)
     const { variableConfig, unitsConversions } = this.props;
     return (
       <Table striped bordered>
@@ -172,7 +171,6 @@ class Summary extends React.Component {
         {
           map(row => {
             // TODO: Extract as component
-            console.log('### Summary: row', row)
             const { variable, display, precision } = row;
             const displayUnits =
               getVariableDisplayUnits(variableConfig, variable, display);
@@ -181,7 +179,6 @@ class Summary extends React.Component {
             const variableInfo =
               getVariableInfo(variableConfig, variable, display);
             return map(season => {
-              console.log('### Summary: season', season)
               // Const `data` is provided as context data to the external text.
               // The external text implements the structure and formatting of
               // this data for display. Slightly tricky, very flexible.
@@ -201,7 +198,6 @@ class Summary extends React.Component {
                 isLong,
                 unitsSuffix,
               };
-              console.log('### Summary: season 2: data', data)
               return (
                 <tr>
                   {

--- a/src/components/data-displays/Summary/Summary.js
+++ b/src/components/data-displays/Summary/Summary.js
@@ -326,22 +326,37 @@ const getPeriodData = (source, period) => {
 
 
 const getDisplayData = (response, period, display) => {
-  // Return the data to be displayed from the response, according to the
-  // selected period (e.g., 'spring') and display type ('absolute' or
-  // 'relative').
+  // Return the data, with units, to be displayed from the response,
+  // according to the selected period (e.g., 'spring') and display type
+  // ('absolute' or 'relative'). Object returned is of the form:
+  //  {
+  //    percentiles: [ ... ],
+  //    units: '...',
+  //  }
 
   if (isUndefined(response)) {
-    return [];  // Empty array -> undefined when subscripted; possibly better to return undefined
+    // TODO: Probably better to return just undefined here.
+    return {
+      // Empty array -> undefined when subscripted; possibly better to return undefined
+      percentiles: [],
+      units: '??',
+    };
   }
 
   const anomalyValues = getPeriodData(response.anomaly, period);
   if (display === 'absolute') {
-    return anomalyValues;
+    return {
+      percentiles: anomalyValues,
+      units: response.units,
+    };
   }
 
-  // display === 'relative': units: %
+  // display === 'relative':
   const baselineValue = getPeriodData(response.baseline, period);
-  return map(x => 100 * x/baselineValue)(anomalyValues);
+  return {
+    percentiles: map(x => 100 * x/baselineValue)(anomalyValues),
+    units: '%',
+  };
 };
 
 
@@ -361,7 +376,7 @@ const tableContentsAndDataToSummarySpec =
       seasons: map(season => {
         return {
           id: season,
-          percentiles: getDisplayData(data, season, display),
+          ...getDisplayData(data, season, display),
         }
       })(seasons),
     };

--- a/src/components/data-displays/Summary/Summary.js
+++ b/src/components/data-displays/Summary/Summary.js
@@ -24,14 +24,6 @@ const getVariableLabel = (variableConfig, variable) =>
   `${variableConfig[variable].label}${variableConfig[variable].derived ? '*' : ''}`;
 
 
-const getUnits = (variableConfig, variable, display) => {
-  if (display === 'relative') {
-    return '%';
-  }
-  return variableConfig[variable].units;
-};
-
-
 const getDisplayUnits = (variableConfig, variable, display) => {
   if (display === 'relative') {
     return {

--- a/src/components/data-displays/Summary/Summary.js
+++ b/src/components/data-displays/Summary/Summary.js
@@ -15,8 +15,8 @@ import T from '../../../temporary/external-text';
 import {
   displayFormat,
   getConvertUnits,
-  getVariableInfo,
   getVariableDisplayUnits,
+  getVariableInfo,
   unitsSuffix,
 } from '../../../utils/variables-and-units';
 import withAsyncData from '../../../HOCs/withAsyncData';
@@ -176,8 +176,6 @@ class Summary extends React.Component {
               getVariableDisplayUnits(variableConfig, variable, display);
             const convertUnits =
               getConvertUnits(unitsConversions, variableConfig, variable);
-            const variableInfo =
-              getVariableInfo(variableConfig, variable, display);
             return map(season => {
               // Const `data` is provided as context data to the external text.
               // The external text implements the structure and formatting of
@@ -188,7 +186,7 @@ class Summary extends React.Component {
               const convertData = convertUnits(season.units, displayUnits);
               const percentiles = map(convertData)(season.percentiles);
               const data = {
-                variable: variableInfo,
+                variable: getVariableInfo(variableConfig, variable, display),
                 season: {
                   ...season,
                   label: capitalize(season.id),

--- a/src/components/maps/ClimateLayer/ClimateLayer.js
+++ b/src/components/maps/ClimateLayer/ClimateLayer.js
@@ -1,12 +1,23 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { WMSTileLayer } from 'react-leaflet';
+import mapValues from 'lodash/fp/mapValues';
 import T from '../../../temporary/external-text';
-import { wmsClimateLayerProps } from '../map-utils';
+import {
+  wmsAboveMaxColor, wmsBelowMinColor,
+  wmsColorScaleRange, wmsDataRange, wmsLayerName,
+  wmsLogscale,
+  wmsNumcolorbands, wmsStyle, wmsTime
+} from '../map-utils';
+import {
+  getConvertUnits,
+  getVariableDisplayUnits
+} from '../../../utils/variables-and-units';
 
 
 export default class ClimateLayer extends React.Component {
   static contextType = T.contextType;
+  getConfig = path => T.get(this.context, path, {}, 'raw');
 
   static propTypes = {
     fileMetadata: PropTypes.object,
@@ -15,16 +26,47 @@ export default class ClimateLayer extends React.Component {
   };
 
   render() {
-    const displaySpec = T.get(this.context, 'maps.displaySpec', {}, 'raw');
+    const { fileMetadata, variableSpec, season } = this.props;
+    const variable = variableSpec.variable_id;
+    const displaySpec = this.getConfig('maps.displaySpec');
+    const variableConfig = this.getConfig('variables');
+    const unitsConversions = this.getConfig('units');
+
+    // Convert the data range for the climate layer from display units, which
+    // are convenient for the user to specify (in the config file), to data
+    // units, which is what the data actually comes in.
+    const rangeInDisplayUnits = wmsDataRange(displaySpec, variableSpec);
+    const displayUnits =
+      getVariableDisplayUnits(variableConfig, variable, 'absolute');
+    // TODO: dataUnits should come from metadata, not config.
+    const dataUnits = variableConfig[variable].dataUnits;
+    const convertUnits =
+      getConvertUnits(unitsConversions, variableConfig, variable);
+    const rangeInDataUnits = mapValues(
+      convertUnits(displayUnits, dataUnits)
+    )(rangeInDisplayUnits);
+
+    const layerProps = {
+      format: 'image/png',
+      logscale: wmsLogscale(displaySpec, variableSpec),
+      noWrap: true,
+      numcolorbands: wmsNumcolorbands,
+      opacity: 0.7,
+      // srs: "EPSG:3005",
+      transparent: true,
+      version: '1.1.1',
+      abovemaxcolor: wmsAboveMaxColor(displaySpec, variableSpec),
+      belowmincolor: wmsBelowMinColor(displaySpec, variableSpec),
+      layers: wmsLayerName(fileMetadata, variableSpec),
+      time: wmsTime(fileMetadata, season),
+      styles: wmsStyle(displaySpec, variableSpec),
+      colorscalerange: wmsColorScaleRange(rangeInDataUnits),
+    };
+
     return (
       <WMSTileLayer
         url={process.env.REACT_APP_NCWMS_URL}
-        {...wmsClimateLayerProps(
-          this.props.fileMetadata,
-          displaySpec,
-          this.props.variableSpec,
-          this.props.season
-        )}
+        {...layerProps}
       />
     );
   }

--- a/src/components/maps/ClimateLayer/ClimateLayer.js
+++ b/src/components/maps/ClimateLayer/ClimateLayer.js
@@ -4,10 +4,15 @@ import { WMSTileLayer } from 'react-leaflet';
 import mapValues from 'lodash/fp/mapValues';
 import T from '../../../temporary/external-text';
 import {
-  wmsAboveMaxColor, wmsBelowMinColor,
-  wmsColorScaleRange, wmsDataRange, wmsLayerName,
+  wmsAboveMaxColor,
+  wmsBelowMinColor,
+  wmsColorScaleRange,
+  wmsDataRange,
+  wmsLayerName,
   wmsLogscale,
-  wmsNumcolorbands, wmsStyle, wmsTime
+  wmsNumcolorbands,
+  wmsStyle,
+  wmsTime
 } from '../map-utils';
 import {
   getConvertUnits,
@@ -27,7 +32,7 @@ export default class ClimateLayer extends React.Component {
 
   render() {
     const { fileMetadata, variableSpec, season } = this.props;
-    const variable = variableSpec.variable_id;
+    const variableId = variableSpec.variable_id;
     const displaySpec = this.getConfig('maps.displaySpec');
     const variableConfig = this.getConfig('variables');
     const unitsConversions = this.getConfig('units');
@@ -37,36 +42,32 @@ export default class ClimateLayer extends React.Component {
     // units, which is what the data actually comes in.
     const rangeInDisplayUnits = wmsDataRange(displaySpec, variableSpec);
     const displayUnits =
-      getVariableDisplayUnits(variableConfig, variable, 'absolute');
+      getVariableDisplayUnits(variableConfig, variableId, 'absolute');
     // TODO: dataUnits should come from metadata, not config.
-    const dataUnits = variableConfig[variable].dataUnits;
+    const dataUnits = variableConfig[variableId].dataUnits;
     const convertUnits =
-      getConvertUnits(unitsConversions, variableConfig, variable);
+      getConvertUnits(unitsConversions, variableConfig, variableId);
     const rangeInDataUnits = mapValues(
       convertUnits(displayUnits, dataUnits)
     )(rangeInDisplayUnits);
 
-    const layerProps = {
-      format: 'image/png',
-      logscale: wmsLogscale(displaySpec, variableSpec),
-      noWrap: true,
-      numcolorbands: wmsNumcolorbands,
-      opacity: 0.7,
-      // srs: "EPSG:3005",
-      transparent: true,
-      version: '1.1.1',
-      abovemaxcolor: wmsAboveMaxColor(displaySpec, variableSpec),
-      belowmincolor: wmsBelowMinColor(displaySpec, variableSpec),
-      layers: wmsLayerName(fileMetadata, variableSpec),
-      time: wmsTime(fileMetadata, season),
-      styles: wmsStyle(displaySpec, variableSpec),
-      colorscalerange: wmsColorScaleRange(rangeInDataUnits),
-    };
-
     return (
       <WMSTileLayer
         url={process.env.REACT_APP_NCWMS_URL}
-        {...layerProps}
+        format={'image/png'}
+        logscale={wmsLogscale(displaySpec, variableSpec)}
+        noWrap={true}
+        numcolorbands={wmsNumcolorbands}
+        opacity={0.7}
+        // srs={"EPSG:3005"}
+        transparent={true}
+        version={'1.1.1'}
+        abovemaxcolor={wmsAboveMaxColor(displaySpec, variableSpec)}
+        belowmincolor={wmsBelowMinColor(displaySpec, variableSpec)}
+        layers={wmsLayerName(fileMetadata, variableSpec)}
+        time={wmsTime(fileMetadata, season)}
+        styles={wmsStyle(displaySpec, variableSpec)}
+        colorscalerange={wmsColorScaleRange(rangeInDataUnits)}
       />
     );
   }

--- a/src/components/maps/TwoDataMaps/TwoDataMaps.js
+++ b/src/components/maps/TwoDataMaps/TwoDataMaps.js
@@ -33,10 +33,12 @@ import DataMap from '../../maps/DataMap';
 import BCBaseMap from '../BCBaseMap';
 import NcwmsColourbar from '../NcwmsColourbar';
 import { regionBounds } from '../map-utils';
+import styles from '../NcwmsColourbar/NcwmsColourbar.module.css';
 
 
 export default class TwoDataMaps extends React.Component {
   static contextType = T.contextType;
+  getConfig = path => T.get(this.context, path, {}, 'raw');
 
   static propTypes = {
     region: PropTypes.string,
@@ -75,14 +77,37 @@ export default class TwoDataMaps extends React.Component {
   handleChangePopup = this.handleChangeSelection.bind(this, 'popup');
 
   render() {
+    const variableSpec = this.props.variable.representative;
+    const variableConfig = this.getConfig('variables');
+    const getUnits = variableSpec =>
+      get(
+        [get('variable_id', variableSpec), 'units'],
+        variableConfig,
+      );
     return (
       <React.Fragment>
         <Row>
           <Col lg={12}>
             <NcwmsColourbar
-              variableSpec={this.props.variable.representative}
               width={20}
               height={600}
+              heading={<T
+                path='colourScale.label'
+                data={{
+                  variable: get('variable_name', variableSpec),
+                  units: getUnits(variableSpec)
+                }}
+                placeholder={null}
+                className={styles.label}
+              />}
+              note={<T
+                path={'colourScale.note'}
+                placeholder={null}
+                className={styles.note}
+              />}
+              variableSpec={variableSpec}
+              displaySpec={this.getConfig('maps.displaySpec')}
+              variableConfig={variableConfig}
             />
           </Col>
         </Row>

--- a/src/components/maps/TwoDataMaps/TwoDataMaps.js
+++ b/src/components/maps/TwoDataMaps/TwoDataMaps.js
@@ -27,13 +27,15 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Row, Col } from 'react-bootstrap';
-import get from 'lodash/fp/get';
 import T from '../../../temporary/external-text';
 import DataMap from '../../maps/DataMap';
 import BCBaseMap from '../BCBaseMap';
 import NcwmsColourbar from '../NcwmsColourbar';
 import { regionBounds } from '../map-utils';
 import styles from '../NcwmsColourbar/NcwmsColourbar.module.css';
+import {
+  getDisplayUnits, getVariableInfo,
+} from '../../../utils/variables-and-units';
 
 
 export default class TwoDataMaps extends React.Component {
@@ -78,12 +80,10 @@ export default class TwoDataMaps extends React.Component {
 
   render() {
     const variableSpec = this.props.variable.representative;
+    const variable = variableSpec.variable_id;
     const variableConfig = this.getConfig('variables');
-    const getUnits = variableSpec =>
-      get(
-        [get('variable_id', variableSpec), 'units'],
-        variableConfig,
-      );
+    const displayUnits =
+      getDisplayUnits(variableConfig, variable);
     return (
       <React.Fragment>
         <Row>
@@ -93,10 +93,11 @@ export default class TwoDataMaps extends React.Component {
               height={600}
               heading={<T
                 path='colourScale.label'
-                data={{
-                  variable: get('variable_name', variableSpec),
-                  units: getUnits(variableSpec)
-                }}
+                data={getVariableInfo(variableConfig, variable, displayUnits)}
+                // data={{
+                //   variable: get('variable_name', variableSpec),
+                //   units: getUnits(variableSpec)
+                // }}
                 placeholder={null}
                 className={styles.label}
               />}

--- a/src/components/maps/TwoDataMaps/TwoDataMaps.js
+++ b/src/components/maps/TwoDataMaps/TwoDataMaps.js
@@ -33,9 +33,7 @@ import BCBaseMap from '../BCBaseMap';
 import NcwmsColourbar from '../NcwmsColourbar';
 import { regionBounds } from '../map-utils';
 import styles from '../NcwmsColourbar/NcwmsColourbar.module.css';
-import {
-  getDisplayUnits, getVariableInfo,
-} from '../../../utils/variables-and-units';
+import { getVariableInfo, } from '../../../utils/variables-and-units';
 
 
 export default class TwoDataMaps extends React.Component {
@@ -82,8 +80,6 @@ export default class TwoDataMaps extends React.Component {
     const variableSpec = this.props.variable.representative;
     const variable = variableSpec.variable_id;
     const variableConfig = this.getConfig('variables');
-    const displayUnits =
-      getDisplayUnits(variableConfig, variable);
     return (
       <React.Fragment>
         <Row>
@@ -93,11 +89,7 @@ export default class TwoDataMaps extends React.Component {
               height={600}
               heading={<T
                 path='colourScale.label'
-                data={getVariableInfo(variableConfig, variable, displayUnits)}
-                // data={{
-                //   variable: get('variable_name', variableSpec),
-                //   units: getUnits(variableSpec)
-                // }}
+                data={getVariableInfo(variableConfig, variable, 'absolute')}
                 placeholder={null}
                 className={styles.label}
               />}
@@ -108,7 +100,6 @@ export default class TwoDataMaps extends React.Component {
               />}
               variableSpec={variableSpec}
               displaySpec={this.getConfig('maps.displaySpec')}
-              variableConfig={variableConfig}
             />
           </Col>
         </Row>

--- a/src/components/maps/map-utils.js
+++ b/src/components/maps/map-utils.js
@@ -39,10 +39,12 @@ export const geometryBounds = geometry => {
 // Return a Leaflet LatLngBounds object bounding the GeoJSON region object.
 export const regionBounds = region => geometryBounds(region.geometry);
 
+
 // Generic map helpers
 
 export const generateResolutions = (maxRes, count) =>
   map(i => maxRes / Math.pow(2, i)) (range(0, count));
+
 
 // WMS tile layer props helpers
 
@@ -79,31 +81,11 @@ export const wmsTicks = getDisplaySpecItem('ticks');
 export const wmsAboveMaxColor = getDisplaySpecItem('aboveMaxColor');
 export const wmsBelowMinColor = getDisplaySpecItem('belowMinColor');
 
+
 export const wmsStyle = (displaySpec, variableSpec) =>
   `default-scalar/${wmsPalette(displaySpec, variableSpec)}`;
 
 
-export const wmsColorScaleRange = (displaySpec, variableSpec) => {
-  const range = wmsDataRange(displaySpec, variableSpec);
+export const wmsColorScaleRange = range => {
   return `${range.min},${range.max}`
-};
-
-
-export const wmsClimateLayerProps = (fileMetadata, displaySpec, variableSpec, season) => {
-  return {
-    format: 'image/png',
-    logscale: wmsLogscale(displaySpec, variableSpec),
-    noWrap: true,
-    numcolorbands: wmsNumcolorbands,
-    opacity: 0.7,
-    // srs: "EPSG:3005",
-    transparent: true,
-    version: '1.1.1',
-    abovemaxcolor: wmsAboveMaxColor(displaySpec, variableSpec),
-    belowmincolor: wmsBelowMinColor(displaySpec, variableSpec),
-    layers: wmsLayerName(fileMetadata, variableSpec),
-    time: wmsTime(fileMetadata, season),
-    styles: wmsStyle(displaySpec, variableSpec),
-    colorscalerange: wmsColorScaleRange(displaySpec, variableSpec),
-  }
 };

--- a/src/utils/variables-and-units.js
+++ b/src/utils/variables-and-units.js
@@ -2,22 +2,26 @@
 // units.
 
 import curry from 'lodash/fp/curry';
+import find from 'lodash/fp/find';
+import flow from 'lodash/fp/flow';
 import isNumber from 'lodash/fp/isNumber';
+import isString from 'lodash/fp/isString';
 
 
 export const getVariableLabel = (variableConfig, variable) =>
   `${variableConfig[variable].label}${variableConfig[variable].derived ? '*' : ''}`;
 
 
-export const getDisplayUnits = (variableConfig, variable, display) => {
-  if (display === 'relative') {
-    return {
-      target: '%',
-      // no conversions
-    };
-  }
-  return variableConfig[variable].displayUnits;
-};
+export const getDisplayUnits =
+  (variableConfig, variable, display = 'absolute') => {
+    if (display === 'relative') {
+      return {
+        target: '%',
+        // no conversions
+      };
+    }
+    return variableConfig[variable].displayUnits;
+  };
 
 
 export const getVariableInfo = (variableConfig, variable, displayUnits) => {
@@ -29,22 +33,20 @@ export const getVariableInfo = (variableConfig, variable, displayUnits) => {
 };
 
 
-export const convertToDisplayUnits = curry(
-  (displayUnits, baseUnits, value) => {
-    if (displayUnits.target === baseUnits) {
-      return value;
-    }
-    try {
-      const conversion = displayUnits.conversions[baseUnits];
-      const { scale, offset } = isNumber(conversion) ?
-        { scale: conversion, offset: 0 } :
-        conversion;
-      return value * scale + offset;
-    } catch (e) {
-      return undefined;
-    }
+export const convertToDisplayUnits = curry((displayUnits, baseUnits, value) => {
+  if (displayUnits.target === baseUnits) {
+    return value;
   }
-);
+  try {
+    const conversion = displayUnits.conversions[baseUnits];
+    const { scale, offset } = isNumber(conversion) ?
+      { scale: conversion, offset: 0 } :
+      conversion;
+    return value * scale + offset;
+  } catch (e) {
+    return undefined;
+  }
+});
 
 
 export const unitsSuffix = units =>
@@ -64,16 +66,71 @@ export const expToFixed = s => {
 };
 
 
-export const displayFormat = (sigfigs = 3) => (value) =>
+export const displayFormat = curry((sigfigs = 3) => (value) => {
   // Convert a number value to a string in the display format we prefer.
-  `${value > 0 ? '+' : ''}${expToFixed(value.toPrecision(sigfigs))}`;
-
-// TODO: Figure out why this fails.
-// export const displayFormat = curry(
-//   (sigfigs = 3, value) =>
-//     // Convert a number value to a string in the display format we prefer.
-//     `${value > 0 ? '+' : ''}${expToFixed(value.toPrecision(sigfigs))}`
-// );
+  if (!isNumber(value)) {
+    return '--';
+  }
+  return `${value > 0 ? '+' : ''}${expToFixed(value.toPrecision(sigfigs))}`;
+});
 
 
+const findWithKey = find.convert({ 'cap': false });
 
+export const findConversionGroup = curry((conversions, units) => {
+  return find(
+    findWithKey((value, key) => key === units)
+  )(conversions);
+});
+
+
+export const canonicalConversion = (conversion) => {
+  return isNumber(conversion) ? { scale: conversion, offset: 0 } : conversion;
+};
+
+
+export const toBaseUnits = curry((conversion, value) =>
+  conversion.scale * value + conversion.offset
+);
+
+
+export const fromBaseUnits = curry((conversion, value) =>
+  (value - conversion.offset) / conversion.scale
+);
+
+
+export const convertUnitsInGroup = curry((conversionGroup, fromUnits, toUnits, value) => {
+  if (fromUnits === toUnits) {  // Identity
+    return value;
+  }
+  const fromConversion = conversionGroup[fromUnits];
+  if (isString(fromConversion)) {  // Synonym
+    return convertUnitsInGroup(conversionGroup, fromConversion, toUnits, value);
+  }
+  const toConversion = conversionGroup[toUnits];
+  if (isString(toConversion)) {  // Synonym
+    return convertUnitsInGroup(conversionGroup, fromUnits, toConversion, value);
+  }
+  return fromBaseUnits(canonicalConversion(toConversion), toBaseUnits(canonicalConversion(fromConversion), value));
+});
+
+
+export const convertUnits = curry((conversions, fromUnits, toUnits, value) => {
+  if (fromUnits === toUnits) {
+    return value;
+  }
+  const cGroup = findConversionGroup(conversions, fromUnits);
+  if (!cGroup) {
+    console.error('undefined units', fromUnits);
+    return undefined;
+  }
+  const cGroup2 = findConversionGroup(conversions, toUnits);
+  if (!cGroup2) {
+    console.error('undefined units', toUnits);
+    return undefined;
+  }
+  if (cGroup !== cGroup2) {
+    console.error('incompatible units', fromUnits, toUnits);
+  }
+  return convertUnitsInGroup(cGroup, fromUnits, toUnits, value);
+});

--- a/src/utils/variables-and-units.js
+++ b/src/utils/variables-and-units.js
@@ -1,0 +1,79 @@
+// Utility functions for displaying variables and their values in specified
+// units.
+
+import curry from 'lodash/fp/curry';
+import isNumber from 'lodash/fp/isNumber';
+
+
+export const getVariableLabel = (variableConfig, variable) =>
+  `${variableConfig[variable].label}${variableConfig[variable].derived ? '*' : ''}`;
+
+
+export const getDisplayUnits = (variableConfig, variable, display) => {
+  if (display === 'relative') {
+    return {
+      target: '%',
+      // no conversions
+    };
+  }
+  return variableConfig[variable].displayUnits;
+};
+
+
+export const getVariableInfo = (variableConfig, variable, displayUnits) => {
+  return {
+    id: variable,
+    label: getVariableLabel(variableConfig, variable),
+    units: displayUnits.target,
+  };
+};
+
+
+export const convertToDisplayUnits = curry(
+  (displayUnits, baseUnits, value) => {
+    if (displayUnits.target === baseUnits) {
+      return value;
+    }
+    try {
+      const conversion = displayUnits.conversions[baseUnits];
+      const { scale, offset } = isNumber(conversion) ?
+        { scale: conversion, offset: 0 } :
+        conversion;
+      return value * scale + offset;
+    } catch (e) {
+      return undefined;
+    }
+  }
+);
+
+
+export const unitsSuffix = units =>
+  `${units.match(/^[%]/) ? '' : ' '}${units}`;
+
+
+export const expToFixed = s => {
+  // Convert a string representing a number in exponential notation to a string
+  // in (nominally) fixed point notation. Why? Because `Number.toPrecision()`
+  // returns exponential notation frequently when we do not want it to. So
+  // we apply this.
+  const match = s.match(/-?\d\.\d+e[+-]\d+/);
+  if (!match) {
+    return s;
+  }
+  return Number.parseFloat(match[0]).toString();
+};
+
+
+export const displayFormat = (sigfigs = 3) => (value) =>
+  // Convert a number value to a string in the display format we prefer.
+  `${value > 0 ? '+' : ''}${expToFixed(value.toPrecision(sigfigs))}`;
+
+// TODO: Figure out why this fails.
+// export const displayFormat = curry(
+//   (sigfigs = 3, value) =>
+//     // Convert a number value to a string in the display format we prefer.
+//     `${value > 0 ? '+' : ''}${expToFixed(value.toPrecision(sigfigs))}`
+// );
+
+
+

--- a/src/utils/variables-and-units.js
+++ b/src/utils/variables-and-units.js
@@ -82,15 +82,6 @@ export const displayFormat = curry((sigfigs = 3) => (value) => {
 // layout of units conversion information is embedded in these functions.
 // TODO: Place in separate module.
 
-const findWithKey = find.convert({ 'cap': false });
-
-export const findConversionGroup = curry((conversions, units) => {
-  return find(
-    findWithKey((value, key) => key === units)
-  )(conversions);
-});
-
-
 export const canonicalConversion = (conversion) => {
   return isNumber(conversion) ? { scale: conversion, offset: 0 } : conversion;
 };
@@ -124,25 +115,3 @@ export const convertUnitsInGroup = curry((conversionGroup, fromUnits, toUnits, v
   return fromBaseUnits(canonicalConversion(toConversion), toBaseUnits(canonicalConversion(fromConversion), value));
 });
 
-
-// TODO: Remove? This is not a very good idea given overlapping types like
-//  precipitation flux an snowfall.
-export const convertUnits = curry((conversions, fromUnits, toUnits, value) => {
-  if (fromUnits === toUnits) {
-    return value;
-  }
-  const cGroup = findConversionGroup(conversions, fromUnits);
-  if (!cGroup) {
-    console.error('undefined units', fromUnits);
-    return undefined;
-  }
-  const cGroup2 = findConversionGroup(conversions, toUnits);
-  if (!cGroup2) {
-    console.error('undefined units', toUnits);
-    return undefined;
-  }
-  if (cGroup !== cGroup2) {
-    console.error('incompatible units', fromUnits, toUnits);
-  }
-  return convertUnitsInGroup(cGroup, fromUnits, toUnits, value);
-});

--- a/src/utils/variables-and-units.test.js
+++ b/src/utils/variables-and-units.test.js
@@ -1,0 +1,135 @@
+import each from 'jest-each';
+import keys from 'lodash/fp/keys';
+import {
+  canonicalConversion, convertUnits, convertUnitsInGroup,
+  findConversionGroup, fromBaseUnits, toBaseUnits
+} from './variables-and-units';
+
+
+const conversions = {
+  'precipitation flux': {
+    'mm/yr': 1,
+    'mm/d': 365,
+    'kg m-1 d-1': 'mm/d',
+  },
+  temperature: {
+    degC: 1,
+    '°C': 'degC',
+    'degF': {
+      scale: 0.55555,
+      offset: -32 * 0.55555,
+    },
+    '°F': 'degF',
+  }
+};
+
+const tGroup = conversions['temperature'];
+const degFconversion = tGroup['degF'];
+
+
+describe('findConversionGroup', () => {
+  describe('existing units', () => {
+    each([
+      ['kg m-1 d-1'],
+      ['mm/d'],
+      ['mm/yr'],
+      ['°C'],
+    ]).test('for %s', (units) => {
+      expect(keys(findConversionGroup(conversions, units))).toContain(units);
+    });
+  });
+  describe('non-existent units', () => {
+    each([
+      ['bargle'],
+      [undefined],
+    ]).test('for %s', (units) => {
+      expect(findConversionGroup(conversions, units)).toBeUndefined();
+    });
+  });
+});
+
+
+describe('canonicalConversion', () => {
+  each([
+    [1, { scale: 1, offset: 0 }],
+    [2, { scale: 2, offset: 0 }],
+    [{ scale: 3, offset: 4 }, { scale: 3, offset: 4 }],
+  ]).test('for %p', (input, expected) => {
+    expect(canonicalConversion(input)).toEqual(expected);
+  });
+});
+
+
+describe('toBaseUnits', () => {
+  each([
+    [1, 0, 2, 2],
+    [1, 1, 2, 3],
+    [10, 1, 2, 21],
+    [degFconversion.scale, degFconversion.offset, 50, 10],
+  ]).it('scale: %d, offset: %d, value: %d', (scale, offset, value, expected) => {
+    expect(toBaseUnits({scale, offset}, value)).toBeCloseTo(expected);
+  });
+});
+
+
+describe('fromBaseUnits', () => {
+  each([
+    [1, 0, 2, 2],
+    [1, 1, 3, 2],
+    [10, 1, 21, 2],
+    [degFconversion.scale, degFconversion.offset, 10, 50],
+  ]).it('scale: %d, offset: %d, value: %d', (scale, offset, value, expected) => {
+    expect(fromBaseUnits({scale, offset}, value)).toBeCloseTo(expected);
+  });
+});
+
+
+describe('compose toBaseUnits, fromBaseUnits', () => {
+  each([
+    [1, 0, 2],
+    [1, 1, 3],
+    [10, 1, 4],
+  ]).it('scale: %d, offset: %d, value: %d', (scale, offset, value) => {
+    const conversion = {scale, offset};
+    expect(fromBaseUnits(conversion, toBaseUnits(conversion, value)))
+      .toBeCloseTo(value);
+    expect(toBaseUnits(conversion, fromBaseUnits(conversion, value)))
+      .toBeCloseTo(value);
+  });
+});
+
+
+describe('convertUnitsInGroup', () => {
+  each([
+    [3, 'degC', 3, 'degC', tGroup],
+    [4, 'degC', 4, '°C', tGroup],
+    [5, '°C', 5, 'degC', tGroup],
+    [10, 'degC', 50, 'degF', tGroup],
+    [10, '°C', 50, 'degF', tGroup],
+    [50, 'degF', 10, 'degC', tGroup],
+    [50, '°F', 10, 'degC', tGroup],
+    [50, '°F', 10, '°C', tGroup],
+  ]).it('%d %s = %d %s', (value, fromUnits, expected, toUnits, group) => {
+    expect(convertUnitsInGroup(group, fromUnits, toUnits, value))
+      .toBeCloseTo(expected);
+  });
+});
+
+
+describe('convertUnits', () => {
+  each([
+    [3, 'degC', 3, 'degC', conversions],
+    [4, 'degC', 4, '°C', conversions],
+    [5, '°C', 5, 'degC', conversions],
+    [10, 'degC', 50, 'degF', conversions],
+    [10, '°C', 50, 'degF', conversions],
+    [50, 'degF', 10, 'degC', conversions],
+    [50, '°F', 10, 'degC', conversions],
+    [50, '°F', 10, '°C', conversions],
+    [5, 'kg m-1 d-1', 5, 'mm/d', conversions],
+    [5, 'mm/d', 5 * 365, 'mm/yr', conversions],
+  ]).test('%d %s = %d %s', (value, fromUnits, expected, toUnits, conversions) => {
+    expect(convertUnits(conversions, fromUnits, toUnits, value))
+    .toBeCloseTo(expected);     
+  });
+});

--- a/src/utils/variables-and-units.test.js
+++ b/src/utils/variables-and-units.test.js
@@ -1,8 +1,7 @@
 import each from 'jest-each';
 import keys from 'lodash/fp/keys';
 import {
-  canonicalConversion, convertUnits, convertUnitsInGroup,
-  findConversionGroup, fromBaseUnits, toBaseUnits
+  canonicalConversion, convertUnitsInGroup, fromBaseUnits, toBaseUnits
 } from './variables-and-units';
 
 
@@ -25,28 +24,6 @@ const conversions = {
 
 const tGroup = conversions['temperature'];
 const degFconversion = tGroup['degF'];
-
-
-describe('findConversionGroup', () => {
-  describe('existing units', () => {
-    each([
-      ['kg m-1 d-1'],
-      ['mm/d'],
-      ['mm/yr'],
-      ['°C'],
-    ]).test('for %s', (units) => {
-      expect(keys(findConversionGroup(conversions, units))).toContain(units);
-    });
-  });
-  describe('non-existent units', () => {
-    each([
-      ['bargle'],
-      [undefined],
-    ]).test('for %s', (units) => {
-      expect(findConversionGroup(conversions, units)).toBeUndefined();
-    });
-  });
-});
 
 
 describe('canonicalConversion', () => {
@@ -112,24 +89,5 @@ describe('convertUnitsInGroup', () => {
   ]).it('%d %s = %d %s', (value, fromUnits, expected, toUnits, group) => {
     expect(convertUnitsInGroup(group, fromUnits, toUnits, value))
       .toBeCloseTo(expected);
-  });
-});
-
-
-describe('convertUnits', () => {
-  each([
-    [3, 'degC', 3, 'degC', conversions],
-    [4, 'degC', 4, '°C', conversions],
-    [5, '°C', 5, 'degC', conversions],
-    [10, 'degC', 50, 'degF', conversions],
-    [10, '°C', 50, 'degF', conversions],
-    [50, 'degF', 10, 'degC', conversions],
-    [50, '°F', 10, 'degC', conversions],
-    [50, '°F', 10, '°C', conversions],
-    [5, 'kg m-1 d-1', 5, 'mm/d', conversions],
-    [5, 'mm/d', 5 * 365, 'mm/yr', conversions],
-  ]).test('%d %s = %d %s', (value, fromUnits, expected, toUnits, conversions) => {
-    expect(convertUnits(conversions, fromUnits, toUnits, value))
-    .toBeCloseTo(expected);     
   });
 });


### PR DESCRIPTION
Resolves #93
 
This PR introduces units conversion utilities driven by a configuration item ('units'). This feature is used to convert units in the Summary tab (values from backend units to display units) and the Maps tab (units and colour scale labelling, but no data conversion).

At the moment it is hard (impossible?) to get the units in which the climate layers are specified from the backend; it is not in the metadata we use to locate climate layers. I will shortly enter issues for this in frontend and backend.