### PR TITLE
Add belowmincolor and abovemaxcolor displays to colourbar

### DIFF
--- a/public/external-text/default.yaml
+++ b/public/external-text/default.yaml
@@ -1,6 +1,6 @@
 app:
   tabs:
-    default: summary
+    default: dev
 
 selectors:
   prologue: I am interested in information about projected climate change ...

--- a/public/external-text/default.yaml
+++ b/public/external-text/default.yaml
@@ -213,8 +213,8 @@ maps:
     fallback:
       palette: seq-Oranges
       logscale: false
+      belowMinColor: white
       aboveMaxColor: black
-      belowMinColor: black
       range:
         min: -50
         max: 50
@@ -240,6 +240,8 @@ maps:
     pr:
       palette: seq-Greens
       logscale: true
+      belowMinColor: white
+      aboveMaxColor: black
       range:
         min: 10
         max: 10000

--- a/public/external-text/default.yaml
+++ b/public/external-text/default.yaml
@@ -1,6 +1,6 @@
 app:
   tabs:
-    default: dev
+    default: summary
 
 selectors:
   prologue: I am interested in information about projected climate change ...
@@ -17,6 +17,9 @@ selectors:
     prefix: for a typical
     postfix: period
     default: 16
+
+dev:
+  visible: false
 
 summary:
   disabled: false

--- a/src/components/app-root/App/App.js
+++ b/src/components/app-root/App/App.js
@@ -29,6 +29,7 @@ import ImpactsTab from '../../data-displays/impacts/ImpactsTab';
 import TwoDataMaps from '../../maps/TwoDataMaps/TwoDataMaps';
 
 import Cards from '../../misc/Cards';
+import DevColourbar from '../../data-displays/DevColourbar';
 
 const baselineTimePeriod = {
   start_date: 1961,
@@ -136,6 +137,39 @@ export default class App extends Component {
               id={'main'}
               defaultActiveKey={getConfig('app.tabs.default')}
             >
+              <Tab
+                eventKey={'dev'}
+                title={'Dev'}
+                className='pt-2'
+                mountOnEnter
+              >
+                <Row>
+                  <Col xs={'auto'} className='pr-0'>
+                    <T path='selectors.variable.prefix'/>
+                  </Col>
+                  <Col sm={4} xs={6}>
+                    <VariableSelector
+                      {...variableSelectorProps}
+                    />
+                  </Col>
+                  <Col xs={'auto'} className='pr-0'>
+                    <T path='selectors.season.prefix'/>
+                  </Col>
+                  <Col lg={2} sm={4} xs={6}>
+                    <SeasonSelector
+                      {...seasonSelectorProps}
+                    />
+                  </Col>
+                  <Col xs={'auto'} className='pr-0'>
+                    <T path='selectors.season.postfix'/>
+                  </Col>
+                </Row>
+                <DevColourbar
+                  season={get('value', this.state.season)}
+                  variable={get('value', this.state.variable)}
+                />
+              </Tab>
+
               <Tab
                 eventKey={'summary'}
                 title={<T as='string' path='summary.tab'/>}

--- a/src/components/app-root/App/App.js
+++ b/src/components/app-root/App/App.js
@@ -137,6 +137,7 @@ export default class App extends Component {
               id={'main'}
               defaultActiveKey={getConfig('app.tabs.default')}
             >
+              {getConfig('dev.visible') &&
               <Tab
                 eventKey={'dev'}
                 title={'Dev'}
@@ -169,6 +170,7 @@ export default class App extends Component {
                   variable={get('value', this.state.variable)}
                 />
               </Tab>
+              }
 
               <Tab
                 eventKey={'summary'}

--- a/src/components/data-displays/DevColourbar.js
+++ b/src/components/data-displays/DevColourbar.js
@@ -27,27 +27,57 @@ export default class DevColourbar extends React.Component {
     const variable = variableSpec.variable_id;
     const variableConfig = this.getConfig('variables');
     return (
-      <Row>
-        <Col lg={12}>
-          <NcwmsColourbar
-            breadth={20}
-            length={80}
-            heading={<T
-              path='colourScale.label'
-              data={getVariableInfo(variableConfig, variable, 'absolute')}
-              placeholder={null}
-              className={styles.label}
-            />}
-            note={<T
-              path={'colourScale.note'}
-              placeholder={null}
-              className={styles.note}
-            />}
-            variableSpec={variableSpec}
-            displaySpec={this.getConfig('maps.displaySpec')}
-          />
-        </Col>
-      </Row>
+      <React.Fragment>
+        <Row>
+          <Col lg={12}>
+            <NcwmsColourbar
+              breadth={20}
+              length={80}
+              heading={<T
+                path='colourScale.label'
+                data={getVariableInfo(variableConfig, variable, 'absolute')}
+                placeholder={null}
+                className={styles.label}
+              />}
+              note={<T
+                path={'colourScale.note'}
+                placeholder={null}
+                className={styles.note}
+              />}
+              variableSpec={variableSpec}
+              displaySpec={this.getConfig('maps.displaySpec')}
+            />
+          </Col>
+        </Row>
+
+        <Row>
+          <Col lg={12}>
+            <div>Other stuff</div>
+          </Col>
+        </Row>
+
+        {/*<Row>*/}
+        {/*  <Col lg={12}>*/}
+        {/*    <NcwmsColourbar*/}
+        {/*      breadth={20}*/}
+        {/*      length={80}*/}
+        {/*      heading={<T*/}
+        {/*        path='colourScale.label'*/}
+        {/*        data={getVariableInfo(variableConfig, variable, 'absolute')}*/}
+        {/*        placeholder={null}*/}
+        {/*        className={styles.label}*/}
+        {/*      />}*/}
+        {/*      note={<T*/}
+        {/*        path={'colourScale.note'}*/}
+        {/*        placeholder={null}*/}
+        {/*        className={styles.note}*/}
+        {/*      />}*/}
+        {/*      variableSpec={variableSpec}*/}
+        {/*      displaySpec={this.getConfig('maps.displaySpec')}*/}
+        {/*    />*/}
+        {/*  </Col>*/}
+        {/*</Row>*/}
+      </React.Fragment>
     );
   }
 }

--- a/src/components/data-displays/DevColourbar.js
+++ b/src/components/data-displays/DevColourbar.js
@@ -1,0 +1,53 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import T from '../../temporary/external-text';
+import { Col, Row } from 'react-bootstrap';
+import NcwmsColourbar from '../maps/NcwmsColourbar';
+import { getVariableInfo } from '../../utils/variables-and-units';
+import styles from '../maps/NcwmsColourbar/NcwmsColourbar.module.css';
+
+export default class DevColourbar extends React.Component {
+  static contextType = T.contextType;
+  getConfig = path => T.get(this.context, path, {}, 'raw');
+
+  static propTypes = {
+    region: PropTypes.string,
+    historicalTimePeriod: PropTypes.object,
+    futureTimePeriod: PropTypes.object,
+    season: PropTypes.number,
+    variable: PropTypes.object,
+    metadata: PropTypes.array,
+  };
+
+  render() {
+    if (!this.props.variable) {
+      return null;
+    }
+    const variableSpec = this.props.variable.representative;
+    const variable = variableSpec.variable_id;
+    const variableConfig = this.getConfig('variables');
+    return (
+      <Row>
+        <Col lg={12}>
+          <NcwmsColourbar
+            breadth={20}
+            length={600}
+            heading={<T
+              path='colourScale.label'
+              data={getVariableInfo(variableConfig, variable, 'absolute')}
+              placeholder={null}
+              className={styles.label}
+            />}
+            note={<T
+              path={'colourScale.note'}
+              placeholder={null}
+              className={styles.note}
+            />}
+            variableSpec={variableSpec}
+            displaySpec={this.getConfig('maps.displaySpec')}
+          />
+        </Col>
+      </Row>
+    );
+  }
+}

--- a/src/components/data-displays/DevColourbar.js
+++ b/src/components/data-displays/DevColourbar.js
@@ -55,28 +55,6 @@ export default class DevColourbar extends React.Component {
             <div>Other stuff</div>
           </Col>
         </Row>
-
-        {/*<Row>*/}
-        {/*  <Col lg={12}>*/}
-        {/*    <NcwmsColourbar*/}
-        {/*      breadth={20}*/}
-        {/*      length={80}*/}
-        {/*      heading={<T*/}
-        {/*        path='colourScale.label'*/}
-        {/*        data={getVariableInfo(variableConfig, variable, 'absolute')}*/}
-        {/*        placeholder={null}*/}
-        {/*        className={styles.label}*/}
-        {/*      />}*/}
-        {/*      note={<T*/}
-        {/*        path={'colourScale.note'}*/}
-        {/*        placeholder={null}*/}
-        {/*        className={styles.note}*/}
-        {/*      />}*/}
-        {/*      variableSpec={variableSpec}*/}
-        {/*      displaySpec={this.getConfig('maps.displaySpec')}*/}
-        {/*    />*/}
-        {/*  </Col>*/}
-        {/*</Row>*/}
       </React.Fragment>
     );
   }

--- a/src/components/data-displays/DevColourbar.js
+++ b/src/components/data-displays/DevColourbar.js
@@ -31,7 +31,7 @@ export default class DevColourbar extends React.Component {
         <Col lg={12}>
           <NcwmsColourbar
             breadth={20}
-            length={600}
+            length={80}
             heading={<T
               path='colourScale.label'
               data={getVariableInfo(variableConfig, variable, 'absolute')}

--- a/src/components/maps/NcwmsColourbar/NcwmsColourbar.js
+++ b/src/components/maps/NcwmsColourbar/NcwmsColourbar.js
@@ -109,7 +109,6 @@ export default class NcwmsColourbar extends React.Component {
 
     return (
       <div className={styles.all} ref={this.thing}>
-        <div></div>
         { heading }
         <div
           className={styles.allColours}
@@ -149,7 +148,7 @@ export default class NcwmsColourbar extends React.Component {
           />
         </div>
         <div
-          className={styles.xxx}
+          className={styles.belowaboveLabels}
           style={{ width: `${belowAboveLength}%`}}
         >
           {'<'} {range.min}
@@ -180,7 +179,7 @@ export default class NcwmsColourbar extends React.Component {
           }
         </div>
         <div
-          className={styles.xxx}
+          className={styles.belowaboveLabels}
           style={{ width: `${belowAboveLength}%`}}
         >
           {'>'} {range.max}

--- a/src/components/maps/NcwmsColourbar/NcwmsColourbar.js
+++ b/src/components/maps/NcwmsColourbar/NcwmsColourbar.js
@@ -95,11 +95,9 @@ export default class NcwmsColourbar extends React.Component {
 
     const logscale = wmsLogscale(displaySpec, variableSpec);
     const scaleOperator = logscale ? Math.log : identity;
-    const range = mapValues(
-      scaleOperator,
-      wmsDataRange(displaySpec, variableSpec)
-    );
-    const rangeSpan = range.max - range.min;
+    const range = wmsDataRange(displaySpec, variableSpec);
+    const rangeScale = mapValues(scaleOperator, range);
+    const rangeSpan = rangeScale.max - rangeScale.min;
     const ticks = wmsTicks(displaySpec, variableSpec);
 
     const belowAboveLength = (100 - length) /2;  //%
@@ -111,8 +109,12 @@ export default class NcwmsColourbar extends React.Component {
 
     return (
       <div className={styles.all} ref={this.thing}>
+        <div></div>
         { heading }
-        <div className={styles.allColours}>
+        <div
+          className={styles.allColours}
+          style={{ height: breadth + 2 }}
+        >
           <span
             className={styles.belowabove}
             style={{
@@ -125,6 +127,7 @@ export default class NcwmsColourbar extends React.Component {
             className={styles.image}
             style={{
               height: imageWidth,
+              top: 5,
               'margin-top': -imageWidth,
               'margin-left': -breadth,
               'margin-right': `${length}%`,
@@ -146,6 +149,12 @@ export default class NcwmsColourbar extends React.Component {
           />
         </div>
         <div
+          className={styles.xxx}
+          style={{ width: `${belowAboveLength}%`}}
+        >
+          {'<'} {range.min}
+        </div>
+        <div
           className={styles.ticks}
           style={{ width: `${length}%` }}
         >
@@ -156,7 +165,7 @@ export default class NcwmsColourbar extends React.Component {
             map(
               tick => {
                 const position =
-                  (scaleOperator(tick) - range.min) / rangeSpan;
+                  (scaleOperator(tick) - rangeScale.min) / rangeSpan;
                 return (
                   <span
                     style={{
@@ -169,6 +178,12 @@ export default class NcwmsColourbar extends React.Component {
               }
             )(ticks)
           }
+        </div>
+        <div
+          className={styles.xxx}
+          style={{ width: `${belowAboveLength}%`}}
+        >
+          {'>'} {range.max}
         </div>
         { note }
       </div>

--- a/src/components/maps/NcwmsColourbar/NcwmsColourbar.js
+++ b/src/components/maps/NcwmsColourbar/NcwmsColourbar.js
@@ -28,6 +28,7 @@ import getOr from 'lodash/fp/getOr';
 import identity from 'lodash/fp/identity';
 import map from 'lodash/fp/map';
 import mapValues from 'lodash/fp/mapValues';
+import union from 'lodash/fp/union';
 import styles from './NcwmsColourbar.module.css';
 import { makeURI } from '../../../utils/uri';
 import {
@@ -35,7 +36,9 @@ import {
   wmsLogscale,
   wmsNumcolorbands,
   wmsPalette,
-  wmsTicks
+  wmsTicks,
+  wmsAboveMaxColor,
+  wmsBelowMinColor,
 } from '../map-utils';
 
 
@@ -56,14 +59,17 @@ const getColorbarURI = (displaySpec, variableSpec, width, height) =>
 
 export default class NcwmsColourbar extends React.Component {
   static propTypes = {
-    // TODO: Change names
     breadth: PropTypes.number,
+    // Size of smaller (vertical) dimension, px.
+
     length: PropTypes.number,
-    belowMinColor: PropTypes.string,
-    aboveMaxColor: PropTypes.string,
+    // Fraction (%) of width of container that colourbar proper occupies.
 
     title: PropTypes.element,
+    // Title element, placed above colourbar
+
     note: PropTypes.element,
+    // Note element, placed below colourbar
 
     variableSpec: PropTypes.object,
 
@@ -73,9 +79,7 @@ export default class NcwmsColourbar extends React.Component {
 
   static defaultProps = {
     breadth: 20,
-    length: 600,
-    belowMinColor: 'black',
-    aboveMaxColor: 'gray',
+    length: 80,
   };
 
   constructor(props) {
@@ -85,7 +89,7 @@ export default class NcwmsColourbar extends React.Component {
 
   render() {
     const {
-      breadth, length, belowMinColor, aboveMaxColor,
+      breadth, length,
       heading, note, displaySpec, variableSpec,
     } = this.props;
 
@@ -100,7 +104,10 @@ export default class NcwmsColourbar extends React.Component {
 
     const belowAboveLength = (100 - length) /2;  //%
     const width = getOr(0, 'current.offsetWidth', this.thing);
-    const imageWidth = width * length / 100;
+    const imageWidth = Math.round(width * length / 100);
+
+    const belowMinColor = wmsBelowMinColor(displaySpec, variableSpec);
+    const aboveMaxColor = wmsAboveMaxColor(displaySpec, variableSpec);
 
     return (
       <div className={styles.all} ref={this.thing}>
@@ -118,7 +125,7 @@ export default class NcwmsColourbar extends React.Component {
             className={styles.image}
             style={{
               height: imageWidth,
-              'margin-top': -imageWidth + breadth/2,
+              'margin-top': -imageWidth,
               'margin-left': -breadth,
               'margin-right': `${length}%`,
             }}
@@ -126,7 +133,7 @@ export default class NcwmsColourbar extends React.Component {
               displaySpec,
               variableSpec,
               breadth,
-              Math.round(imageWidth)
+              imageWidth
             )}
           />
           <span

--- a/src/components/maps/NcwmsColourbar/NcwmsColourbar.js
+++ b/src/components/maps/NcwmsColourbar/NcwmsColourbar.js
@@ -19,7 +19,7 @@
 //    colour variation runs horizontally, and the whole thing is wider than
 //    high.
 //
-//  - Props `width` and `height` are for the unrotated (vertical) graphic;
+//  - Props `breadth` and `length` are for the unrotated (vertical) graphic;
 //    so their meaning is reversed in the rendered graphic. Confusing, sorry.
 
 import PropTypes from 'prop-types';
@@ -56,8 +56,8 @@ const getColorbarURI = (displaySpec, variableSpec, width, height) =>
 export default class NcwmsColourbar extends React.Component {
   static propTypes = {
     // TODO: Change names
-    width: PropTypes.number,
-    height: PropTypes.number,
+    breadth: PropTypes.number,
+    length: PropTypes.number,
 
     title: PropTypes.element,
     note: PropTypes.element,
@@ -69,12 +69,12 @@ export default class NcwmsColourbar extends React.Component {
   };
 
   static defaultProps = {
-    width: 20,
-    height: 300,
+    breadth: 20,
+    length: 600,
   };
 
   render() {
-    const { width, height, heading, note, displaySpec, variableSpec  } =
+    const { breadth, length, heading, note, displaySpec, variableSpec  } =
       this.props;
     const logscale = wmsLogscale(displaySpec, variableSpec);
     const scaleOperator = logscale ? Math.log : identity;
@@ -87,20 +87,20 @@ export default class NcwmsColourbar extends React.Component {
     return (
       <div
           className={styles.wrapper}
-          style={{ width: height + 20 }}
+          style={{ width: length + 20 }}
         >
           { heading }
           <img
             className={styles.image}
             style={{
-              'margin-top': -height,
-              'margin-left': -width,
+              'margin-top': -length,
+              'margin-left': -breadth,
             }}
             src={getColorbarURI(
               displaySpec,
               variableSpec,
-              width,
-              height
+              breadth,
+              length
             )}
           />
           <div className={styles.ticks}>

--- a/src/components/maps/NcwmsColourbar/NcwmsColourbar.js
+++ b/src/components/maps/NcwmsColourbar/NcwmsColourbar.js
@@ -18,9 +18,6 @@
 //  - At present the colour bar is rendered only horizontally (i.e., the
 //    colour variation runs horizontally, and the whole thing is wider than
 //    high.
-//
-//  - Props `breadth` and `length` are for the unrotated (vertical) graphic;
-//    so their meaning is reversed in the rendered graphic. Confusing, sorry.
 
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -63,7 +60,7 @@ export default class NcwmsColourbar extends React.Component {
     // Size of smaller (vertical) dimension, px.
 
     length: PropTypes.number,
-    // Fraction (%) of width of container that colourbar proper occupies.
+    // Fraction (%) of width of container that colourbar graphic occupies.
 
     title: PropTypes.element,
     // Title element, placed above colourbar
@@ -131,12 +128,7 @@ export default class NcwmsColourbar extends React.Component {
               'margin-left': -breadth,
               'margin-right': `${length}%`,
             }}
-            src={getColorbarURI(
-              displaySpec,
-              variableSpec,
-              breadth,
-              imageWidth
-            )}
+            src={getColorbarURI(displaySpec, variableSpec, breadth, imageWidth)}
           />
           <span
             className={styles.belowabove}
@@ -166,11 +158,7 @@ export default class NcwmsColourbar extends React.Component {
                 const position =
                   (scaleOperator(tick) - rangeScale.min) / rangeSpan;
                 return (
-                  <span
-                    style={{
-                      left: `${position * 100}%`
-                    }}
-                  >
+                  <span style={{ left: `${position * 100}%` }}>
                     {tick}
                   </span>
                 )

--- a/src/components/maps/NcwmsColourbar/NcwmsColourbar.module.css
+++ b/src/components/maps/NcwmsColourbar/NcwmsColourbar.module.css
@@ -2,7 +2,7 @@
     margin-left: auto;
     margin-right: auto;
     padding: 10px;
-    width: 320px;  /* for nominal 300px height */
+    width: 320px;  /* for nominal 300px length */
 }
 
 .wrapper .label {
@@ -13,7 +13,7 @@
 .wrapper .image {
     transform: rotate(90deg);
     transform-origin: bottom right;
-    margin-top: -300px;  /* for nominal 300px height */
+    margin-top: -300px;  /* for nominal 300px length */
     margin-bottom: 0px;
 }
 

--- a/src/components/maps/NcwmsColourbar/NcwmsColourbar.module.css
+++ b/src/components/maps/NcwmsColourbar/NcwmsColourbar.module.css
@@ -6,38 +6,55 @@
 .allColours {
     margin-left: auto;
     margin-right: auto;
+    border: 1px solid lightgrey;
 }
 
 .image {
     display: inline-block;
     position: relative;
-    top: 5px;
     transform: rotate(90deg);
     transform-origin: bottom right;
     margin-bottom: 0px;
 }
 
 .belowabove {
+    position: relative;
     display: inline-block;
 }
 
+.belowabove span {
+    font-size: 90%;
+    color: white;
+    mix-blend-mode: difference;
+}
+
 .ticks {
+    display: inline-block;
     position: relative;
     height: 20px;
     width: 800px;
-    margin-left: auto;
-    margin-right: auto;
+    /*margin-left: auto;*/
+    /*margin-right: auto;*/
 }
 
 .ticks span {
     font-size: 90%;
     position: absolute;
     top: 0px;
-    border-left: 1px solid darkgrey;
+    border-left: 1px solid black;
     padding-left: 3px;
     line-height: 0px;
     padding-top: 10px;
     padding-bottom: 0px;
+}
+
+.xxx {
+    position: relative;
+    display: inline-block;
+    top: -1.7em;
+    font-size: 90%;
+    color: white;
+    mix-blend-mode: exclusion;
 }
 
 .label {

--- a/src/components/maps/NcwmsColourbar/NcwmsColourbar.module.css
+++ b/src/components/maps/NcwmsColourbar/NcwmsColourbar.module.css
@@ -1,39 +1,53 @@
-.wrapper {
+.all {
+    overflow: hidden;
+    text-align: center;
+}
+
+.allColours {
     margin-left: auto;
     margin-right: auto;
-    padding: 10px;
-    width: 320px;  /* for nominal 300px length */
 }
 
-.wrapper .label {
-    text-align: center;
-    margin-bottom: -0.4rem;
-}
-
-.wrapper .image {
+.image {
+    display: inline-block;
+    position: relative;
+    top: 5px;
     transform: rotate(90deg);
     transform-origin: bottom right;
-    margin-top: -300px;  /* for nominal 300px length */
     margin-bottom: 0px;
+}
+
+.belowabove {
+    display: inline-block;
 }
 
 .ticks {
     position: relative;
     height: 20px;
+    width: 800px;
+    margin-left: auto;
+    margin-right: auto;
 }
 
 .ticks span {
     font-size: 90%;
     position: absolute;
-    top: -10px;
+    top: 0px;
     border-left: 1px solid darkgrey;
     padding-left: 3px;
     line-height: 0px;
     padding-top: 10px;
+    padding-bottom: 0px;
 }
 
-.wrapper .note {
+.label {
+    text-align: center;
+    margin-top: 1rem;
+    margin-bottom: -0.4rem;
+}
+
+.note {
     font-size: 80%;
     text-align: center;
-    margin-top: -0.75rem;
+    /*margin-top: -0.75rem;*/
 }

--- a/src/components/maps/NcwmsColourbar/NcwmsColourbar.module.css
+++ b/src/components/maps/NcwmsColourbar/NcwmsColourbar.module.css
@@ -22,19 +22,11 @@
     display: inline-block;
 }
 
-.belowabove span {
-    font-size: 90%;
-    color: white;
-    mix-blend-mode: difference;
-}
-
 .ticks {
     display: inline-block;
     position: relative;
     height: 20px;
     width: 800px;
-    /*margin-left: auto;*/
-    /*margin-right: auto;*/
 }
 
 .ticks span {
@@ -48,7 +40,7 @@
     padding-bottom: 0px;
 }
 
-.xxx {
+.belowaboveLabels {
     position: relative;
     display: inline-block;
     top: -1.7em;

--- a/src/components/maps/TwoDataMaps/TwoDataMaps.js
+++ b/src/components/maps/TwoDataMaps/TwoDataMaps.js
@@ -86,7 +86,7 @@ export default class TwoDataMaps extends React.Component {
           <Col lg={12}>
             <NcwmsColourbar
               breadth={20}
-              length={600}
+              length={80}
               heading={<T
                 path='colourScale.label'
                 data={getVariableInfo(variableConfig, variable, 'absolute')}

--- a/src/components/maps/TwoDataMaps/TwoDataMaps.js
+++ b/src/components/maps/TwoDataMaps/TwoDataMaps.js
@@ -85,8 +85,8 @@ export default class TwoDataMaps extends React.Component {
         <Row>
           <Col lg={12}>
             <NcwmsColourbar
-              width={20}
-              height={600}
+              breadth={20}
+              length={600}
               heading={<T
                 path='colourScale.label'
                 data={getVariableInfo(variableConfig, variable, 'absolute')}


### PR DESCRIPTION
Resolves #103 

This PR also modifies how the colourbar's length (horizontal extent) is established: It fills the entire width of its container, and the colourbar proper (excluding belowmin and abovemax segments) is set as a %age of that width. The remaining width is split between the belowmin and abovemax segments.

Also a few small tweaks to improve appearance.