### PR TITLE
Reset map viewport only on region change

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-REACT_APP_CE_BACKEND_URL=https://services.pacificclimate.org/plan2adapt/ceb
+REACT_APP_CE_BACKEND_URL=https://services.pacificclimate.org/pcex/api/
 REACT_APP_TILECACHE_URL=https://b.tile.pacificclimate.org/tilecache/tilecache.py
 REACT_APP_NCWMS_URL=https://services.pacificclimate.org/pcex/ncwms
 REACT_APP_REGIONS_SERVICE_URL=https://services.pacificclimate.org/plan2adapt/regions/ows

--- a/src/components/maps/DataMap/DataMap.js
+++ b/src/components/maps/DataMap/DataMap.js
@@ -109,8 +109,9 @@ class DataMapDisplay extends React.Component {
   });
 
   render() {
-    const { region, timePeriod, season, variable, popup, fileMetadata, ...rest }
-      = this.props;
+    const {
+      children, region, timePeriod, season, variable, popup, fileMetadata, ...rest
+    } = this.props;
 
     return (
       <CanadaBaseMap
@@ -129,6 +130,7 @@ class DataMapDisplay extends React.Component {
           <LayerValuePopup{...popup} onClose={this.handleClosePopup}/>
         }
         <SimpleGeoJSON data={region} fill={false}/>
+        { children }
       </CanadaBaseMap>
     );
   }

--- a/src/components/maps/StaticControl/StaticControl.css
+++ b/src/components/maps/StaticControl/StaticControl.css
@@ -1,0 +1,5 @@
+:global(.StaticControl) {
+    border: 2px solid rgba(0,0,0,0.2);
+    border-radius: 5px;
+    background: white;
+}

--- a/src/components/maps/StaticControl/StaticControl.js
+++ b/src/components/maps/StaticControl/StaticControl.js
@@ -1,0 +1,33 @@
+import ReactDom from 'react-dom';
+
+import { MapControl, withLeaflet } from 'react-leaflet';
+import L from 'leaflet';
+
+import './StaticControl.css';
+
+
+class StaticControl extends MapControl {
+    createLeafletElement(props) {
+      const leafletElement = L.control({ position: props && props.position });
+
+      leafletElement.onAdd = map => {
+        this.container = L.DomUtil.create(
+          'div',
+          'StaticControl leaflet-control'
+        );
+        Object.assign(this.container.style, props.style);
+        ReactDom.render(props.children, this.container);
+        return this.container;
+      };
+
+      return leafletElement;
+    }
+
+    updateLeafletElement(fromProps, toProps) {
+      if (fromProps.children !== toProps.children) {
+        ReactDom.render(toProps.children, this.container);
+      }
+    }
+}
+
+export default withLeaflet(StaticControl);

--- a/src/components/maps/StaticControl/__tests__/smoke.js
+++ b/src/components/maps/StaticControl/__tests__/smoke.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { Map } from 'react-leaflet';
+import StaticControl from '../';
+
+it('renders without crashing', () => {
+    const div = document.createElement('div');
+    div.style.height = 100;
+    ReactDOM.render(
+        <Map>
+            <StaticControl position='topright'>Test</StaticControl>
+        </Map>,
+        div
+    );
+});

--- a/src/components/maps/StaticControl/package.json
+++ b/src/components/maps/StaticControl/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "StaticControl",
+  "version": "0.0.0",
+  "private": true,
+  "main": "./StaticControl.js"
+}

--- a/src/components/maps/TwoDataMaps/TwoDataMaps.js
+++ b/src/components/maps/TwoDataMaps/TwoDataMaps.js
@@ -35,6 +35,8 @@ import NcwmsColourbar from '../NcwmsColourbar';
 import { regionBounds, wmsLogscale } from '../map-utils';
 import styles from '../NcwmsColourbar/NcwmsColourbar.module.css';
 import { getVariableInfo, } from '../../../utils/variables-and-units';
+import Button from 'react-bootstrap/Button';
+import StaticControl from '../StaticControl';
 
 
 export default class TwoDataMaps extends React.Component {
@@ -81,6 +83,9 @@ export default class TwoDataMaps extends React.Component {
   }
   handleChangePopup = this.handleChangeSelection.bind(this, 'popup');
 
+  zoomToRegion = () =>
+    this.setState({ bounds: regionBounds(this.props.region)});
+
   render() {
     if (!(
       this.props.region &&
@@ -96,6 +101,19 @@ export default class TwoDataMaps extends React.Component {
     const variableConfig = this.getConfig('variables');
     const displaySpec = this.getConfig('maps.displaySpec');
     const logscale = wmsLogscale(displaySpec, variableSpec);
+    const zoomButton = (
+      <StaticControl position='topright'>
+        <Button
+          variant="outline-primary"
+          size={'sm'}
+          onClick={this.zoomToRegion}
+          style={{ zIndex: 99999 }}
+        >
+          Zoom to region
+        </Button>
+      </StaticControl>
+    );
+
     return (
       <React.Fragment>
         <Row>
@@ -138,7 +156,9 @@ export default class TwoDataMaps extends React.Component {
               variable={this.props.variable}
               timePeriod={this.props.historicalTimePeriod}
               metadata={this.props.metadata}
-            />
+            >
+              {zoomButton}
+            </DataMap>
           </Col>
           <Col lg={6}>
             <T path='maps.projected.title' data={{
@@ -157,7 +177,9 @@ export default class TwoDataMaps extends React.Component {
               variable={this.props.variable}
               timePeriod={this.props.futureTimePeriod}
               metadata={this.props.metadata}
-            />
+            >
+              {zoomButton}
+            </DataMap>
           </Col>
         </Row>
       </React.Fragment>

--- a/src/components/maps/TwoDataMaps/TwoDataMaps.js
+++ b/src/components/maps/TwoDataMaps/TwoDataMaps.js
@@ -27,6 +27,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Row, Col } from 'react-bootstrap';
+import Loader from 'react-loader';
 import T from '../../../temporary/external-text';
 import DataMap from '../../maps/DataMap';
 import BCBaseMap from '../BCBaseMap';
@@ -77,6 +78,15 @@ export default class TwoDataMaps extends React.Component {
   handleChangePopup = this.handleChangeSelection.bind(this, 'popup');
 
   render() {
+    if (!(
+      this.props.region &&
+      this.props.futureTimePeriod &&
+      this.props.variable &&
+      this.props.season
+    )) {
+      console.log('### TwoDataMaps: unsettled props', this.props)
+      return <Loader/>
+    }
     const variableSpec = this.props.variable.representative;
     const variable = variableSpec.variable_id;
     const variableConfig = this.getConfig('variables');
@@ -99,7 +109,7 @@ export default class TwoDataMaps extends React.Component {
                 path={'colourScale.note'}
                 placeholder={null}
                 className={styles.note}
-                data={{logscale}}
+                data={{ logscale }}
               />}
               variableSpec={variableSpec}
               displaySpec={displaySpec}

--- a/src/components/maps/TwoDataMaps/TwoDataMaps.js
+++ b/src/components/maps/TwoDataMaps/TwoDataMaps.js
@@ -74,7 +74,11 @@ export default class TwoDataMaps extends React.Component {
   }
 
   handleChangeSelection = (name, value) => this.setState({ [name]: value });
-  handleChangeViewport = this.handleChangeSelection.bind(this, 'viewport');
+  handleChangeViewport = viewport => {
+    // When viewport is changed, remove bounds so that viewport takes
+    // precedence.
+    this.setState({ bounds: undefined, viewport })
+  }
   handleChangePopup = this.handleChangeSelection.bind(this, 'popup');
 
   render() {


### PR DESCRIPTION
Resolves https://github.com/pacificclimate/plan2adapt-v2/issues/136

This PR also adds a "Zoom to region" button to the maps, so that if you move away from your region you can get back without having to go through some region selector rigmarole. Seemed to be begging for it, looks cool.