### PR TITLE
Add Github Actions

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -5,7 +5,7 @@ on: push
 jobs:
   node-test:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@master
     - name: Set up Node.js 9.2
       uses: actions/setup-node@v1
       with:

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -1,0 +1,19 @@
+name: CI Tests
+
+on: push
+
+jobs:
+  node-test:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Node.js 9.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: 9.x
+    - name: Node.js Test Suite
+      run: |
+        npm install
+        npm test

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Node.js 9.x
+    - name: Set up Node.js 9.2
       uses: actions/setup-node@v1
       with:
-        node-version: 9.x
+        node-version: 9.2
     - name: Node.js Test Suite
       run: |
         npm install

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   docker-publish:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - uses: actions/checkout@master

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,35 @@
+name: Docker Publishing
+
+on:
+  push:
+    tags:
+      - '*'
+    branches:
+      - '*'
+
+jobs:
+  docker-publish:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@master
+    - run: git pull --unshallow
+    - name: Get Branch
+      uses: nelonoel/branch-name@v1
+    - name: Get Tag
+      uses: olegtarasov/get-tag@v2
+    - name: Set env vars for build
+      run: |
+        echo ::set-env name=BRANCH::$(echo ${BRANCH_NAME})
+        echo ::set-env name=TAG::$(echo ${GIT_TAG_NAME})
+    - name: Run commitish script
+      run: ./generate-commitish.sh
+    - name: Publish to Registry
+      uses: elgohr/Publish-Docker-Github-Action@master
+      with:
+        name: pcic/climate-explorer-frontend
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        tags: "${{ env.BRANCH }},${{ env.TAG }}"
+        buildargs: ${REACT_APP_VERSION}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Publish to Registry
       uses: elgohr/Publish-Docker-Github-Action@master
       with:
-        name: pcic/climate-explorer-frontend
+        name: pcic/plan2adapt-v2-frontend
         username: ${{ secrets.pcicdevops_at_dockerhub_username }}
         password: ${{ secrets.pcicdevops_at_dockerhub_password }}
         tags: "${{ env.BRANCH }},${{ env.TAG }}"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -23,7 +23,7 @@ jobs:
       run: |
         echo ::set-env name=BRANCH::$(echo ${BRANCH_NAME})
         echo ::set-env name=TAG::$(echo ${GIT_TAG_NAME})
-    - name: Run commitish script
+    - name: Export REACT_APP_VERSION env var
       run: ./generate-commitish.sh
     - name: Publish to Registry
       uses: elgohr/Publish-Docker-Github-Action@master

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -29,7 +29,7 @@ jobs:
       uses: elgohr/Publish-Docker-Github-Action@master
       with:
         name: pcic/climate-explorer-frontend
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
+        username: ${{ secrets.pcicdevops_at_dockerhub_username }}
+        password: ${{ secrets.pcicdevops_at_dockerhub_password }}
         tags: "${{ env.BRANCH }},${{ env.TAG }}"
         buildargs: ${REACT_APP_VERSION}

--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -1,0 +1,30 @@
+name: Image Scan
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  anchore:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Wait for image to be published
+        uses: fountainhead/action-wait-for-check@v1.0.0
+        id: wait-for-build
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          checkName: docker-publish
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Get Branch Name
+        uses: nelonoel/branch-name@v1
+      - name: Set Branch Name to Environment Variable
+        run: echo ::set-env name=TAG::$(echo ${BRANCH_NAME})
+      - name: Scan Image
+        uses: anchore/scan-action@master
+        with:
+          image-reference: "pcic/climate-explorer-frontend:${{ env.TAG }}"
+          fail-build: true
+        if: steps.wait-for-build.outputs.conclusion == 'success'

--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   anchore:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
       - name: Wait for image to be published

--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -25,6 +25,6 @@ jobs:
       - name: Scan Image
         uses: anchore/scan-action@master
         with:
-          image-reference: "pcic/climate-explorer-frontend:${{ env.TAG }}"
+          image-reference: "pcic/plan2adapt-v2-frontend:${{ env.TAG }}"
           fail-build: true
         if: steps.wait-for-build.outputs.conclusion == 'success'

--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -18,13 +18,9 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           checkName: docker-publish
           ref: ${{ github.event.pull_request.head.sha }}
-      - name: Get Branch Name
-        uses: nelonoel/branch-name@v1
-      - name: Set Branch Name to Environment Variable
-        run: echo ::set-env name=TAG::$(echo ${BRANCH_NAME})
       - name: Scan Image
         uses: anchore/scan-action@master
         with:
-          image-reference: "pcic/plan2adapt-v2-frontend:${{ env.TAG }}"
+          image-reference: "pcic/plan2adapt-v2-frontend:${{ github.event.pull_request.head.ref }}"
           fail-build: true
         if: steps.wait-for-build.outputs.conclusion == 'success'

--- a/generate-commitish.sh
+++ b/generate-commitish.sh
@@ -5,4 +5,5 @@ VERSIONTAG="$(git describe --tags --abbrev=0)"
 BRANCH="$(git rev-parse --abbrev-ref HEAD)"
 COMMITSHA="$(git log -1 --format=%h)"
 
+export REACT_APP_VERSION="$VERSIONTAG ($BRANCH: $COMMITSHA)"
 echo "$VERSIONTAG ($BRANCH: $COMMITSHA)"


### PR DESCRIPTION
Adds github actions to the repo.  The workflows will take over the responsibilities of Jenkins and Travis which are:
- run node test suite (on all pushes)
- build and publish docker image (on all branches + on tag creation)
- anchore scan docker image (on PRs targeting `master`)

There was also a small change to `generate-commitish.sh` such that it could be used in the workflow.