### PR TITLE
Fix maps metadata crash

### DIFF
--- a/src/HOCs/withAsyncData.js
+++ b/src/HOCs/withAsyncData.js
@@ -16,11 +16,16 @@
 
 import React from 'react';
 import Loader from 'react-loader';
+import merge from 'lodash/fp/merge';
 
 
 const getDisplayName = WrappedComponent =>
   WrappedComponent.displayName || WrappedComponent.name || 'Component';
 
+const defaultHandlers = {
+  loading: Loader,
+  error: ({ error }) => error.toString(),
+};
 
 export default function withAsyncData(
   loadAsyncData,
@@ -41,10 +46,7 @@ export default function withAsyncData(
   dataPropName,
   // Name of prop to pass data to base component through.
 
-  handlers = {
-    loading: Loader,
-    error: ({ error }) => error.toString(),
-  },
+  handlerOptions = {},
   // Components rendered in loading and error states. States are:
   //  loading: props[dataPropName] === null && !props[errorPropName]
   //  error: props[errorPropName] !== null
@@ -109,6 +111,7 @@ export default function withAsyncData(
 
       render() {
         const { error, externalData } = this.state;
+        const handlers = merge(defaultHandlers, handlerOptions);
         if (error) {
           return <handlers.error {...this.props} error={error}/>;
         }
@@ -117,7 +120,7 @@ export default function withAsyncData(
         }
         return (
           <BaseComponent
-            {...{ [dataPropName]: this.state.externalData }}
+            {...{ [dataPropName]: externalData }}
             {...this.props}
           />
         );

--- a/src/components/maps/TwoDataMaps/TwoDataMaps.js
+++ b/src/components/maps/TwoDataMaps/TwoDataMaps.js
@@ -37,6 +37,7 @@ import styles from '../NcwmsColourbar/NcwmsColourbar.module.css';
 import { getVariableInfo, } from '../../../utils/variables-and-units';
 import Button from 'react-bootstrap/Button';
 import StaticControl from '../StaticControl';
+import { allDefined } from '../../../utils/lodash-fp-extras';
 
 
 export default class TwoDataMaps extends React.Component {
@@ -87,15 +88,22 @@ export default class TwoDataMaps extends React.Component {
     this.setState({ bounds: regionBounds(this.props.region)});
 
   render() {
-    if (!(
-      this.props.region &&
-      this.props.futureTimePeriod &&
-      this.props.variable &&
-      this.props.season
+    if (!allDefined(
+      [
+        'region.geometry',
+        'historicalTimePeriod.start_date',
+        'historicalTimePeriod.end_date',
+        'futureTimePeriod.start_date',
+        'futureTimePeriod.end_date',
+        'variable.representative',
+        'season',
+      ],
+      this.props
     )) {
       console.log('### TwoDataMaps: unsettled props', this.props)
       return <Loader/>
     }
+    console.log('### TwoDataMaps: props', this.props)
     const variableSpec = this.props.variable.representative;
     const variable = variableSpec.variable_id;
     const variableConfig = this.getConfig('variables');

--- a/src/utils/lodash-fp-extras.js
+++ b/src/utils/lodash-fp-extras.js
@@ -2,15 +2,31 @@ import fromPairs from 'lodash/fp/fromPairs';
 import flatten from 'lodash/fp/flatten';
 import isArray from 'lodash/fp/isArray';
 import flow from 'lodash/fp/flow';
-import map from 'lodash/fp/map';
 import convert from 'lodash/fp/convert';
 import placeholder from 'lodash/fp/placeholder';
+import isUndefined from 'lodash/fp/isUndefined';
+import curry from 'lodash/fp/curry';
+import map from 'lodash/fp/map';
+import get from 'lodash/fp/get';
+import every from 'lodash/fp/every';
 
 import { concatAll as stdConcatAll } from './lodash-extras';
 
 
 export const concatAll = convert('concatAll', stdConcatAll);
 concatAll.placeholder = placeholder;
+
+
+export const isDefined = v => !isUndefined(v);
+
+
+export const allDefined = curry((paths, object) => {
+  // Returns a boolean indicating whether every path in `paths` accesses
+  // a defined item in object.
+  const items = map(path => get(path, object))(paths);
+  return every(isDefined, items);
+});
+
 
 
 export const fromPairsMulti = pairs => {

--- a/src/utils/lodash-fp-extras.test.js
+++ b/src/utils/lodash-fp-extras.test.js
@@ -1,5 +1,6 @@
 import each from 'jest-each';
-import { concatAll } from './lodash-fp-extras';
+import { concatAll, allDefined } from './lodash-fp-extras';
+
 
 describe('concatAll', () => {
   each([
@@ -14,3 +15,24 @@ describe('concatAll', () => {
     expect(concatAll(input)).toEqual(expected);
   })
 });
+
+describe('allDefined', () => {
+  each([
+    [[], {}, true],
+    [['a'], {}, false],
+    [['a.b'], {}, false],
+    [['a', 'b'], {}, false],
+    [['a'], { 'a': 0 }, true],
+    [['a'], { 'a': 1 }, true],
+    [['a'], { 'a': 99 }, true],
+    [['a'], { 'a': false }, true],
+    [['a'], { 'a': true }, true],
+    [['b'], { 'a': 0 }, false],
+    [['a', 'b'], { 'a': 9, 'b': 99 }, true],
+    [['a.b'], { 'a': { 'b': 99 }  }, true],
+    [['a.b', 'a.b.c'], { 'a': { 'b': 99 }  }, false],
+  ]).test('%p', (paths, object, expected) => {
+    expect(allDefined(paths, object)).toEqual(expected);
+  })
+});
+

--- a/src/utils/percentile-anomaly.js
+++ b/src/utils/percentile-anomaly.js
@@ -86,10 +86,23 @@ export const getPeriodData = (source, period) => {
   // quirks that can vary the centre date by a day or two. It is independent of
   // year.
   const timescaleItems = source[periodToTimescale(period)];
+  if (!timescaleItems) {
+    throw new Error(
+      `No data for timescale '${periodToTimescale(period)}' 
+      (period '${period}')`
+    );
+  }
   return flow(
     keys,
     find(key => key.substring(5, 7) === periodToMonth(period)),
-    dataKey => timescaleItems[dataKey],
+    dataKey => {
+      if (!dataKey) {
+        throw new Error(
+          `No data for period '${period}' (month ${periodToMonth(period)})`
+        );
+      }
+      return timescaleItems[dataKey]
+    },
   )(timescaleItems);
 };
 


### PR DESCRIPTION
Resolves #146 

Also resolves an error in the Graphs tab arising from a similar cause.

The fix is primarily to the HOC `withAsyncData`, which abstracts out the canonical asynchronous data fetch that all of the data-driven components use. `withAsyncData` now handles fetch errors more robustly, rendering an error indicator component when an error occurs, in a parallel with the existing behaviour of rendering a loading component when data is still loading. The user can now specify what those components are, though they also have reasonable default values (a simple error message, the Loader spinner, respectively).

Given the improved `withAsyncData`, it was simple to make both the Maps tab and the Graphs tab show a helpful error message when the requested data could not be loaded (for differing reasons in each case, but with a unified error handling process).