### PR TITLE
Fix map mess-up when selector changes made on another tab

### DIFF
--- a/src/components/app-root/App/App.js
+++ b/src/components/app-root/App/App.js
@@ -63,7 +63,7 @@ export default class App extends Component {
   handleChangeVariable = this.handleChangeSelection.bind(this, 'variable');
   handleChangeTab = this.handleChangeSelection.bind(this, 'tabKey');
 
-  selectorEnabled = name =>
+    selectorEnabled = name =>
     includes(this.state.tabKey)(this.getConfig(`selectors.${name}.forTabs`));
 
   render() {
@@ -272,6 +272,7 @@ export default class App extends Component {
                   season={get('value', this.state.season)}
                   variable={get('value', this.state.variable)}
                   metadata={this.state.metadata}
+                  active={this.state.tabKey === 'maps'}
                 />
               </Tab>
 

--- a/src/components/app-root/App/App.js
+++ b/src/components/app-root/App/App.js
@@ -214,22 +214,26 @@ export default class App extends Component {
                 className='pt-2'
                 mountOnEnter
               >
-                <T path='summary.notes.general' data={{
-                  region: region,
-                  baselineTimePeriod,
-                  futureTimePeriod,
-                  futureDecade: middleDecade(futureTimePeriod),
-                  baselineDecade: middleDecade(baselineTimePeriod),
-                }}/>
-                <Summary
-                  region={get('value', this.state.region)}
-                  futureTimePeriod={futureTimePeriod}
-                  tableContents={this.getConfig('summary.table.contents')}
-                  variableConfig={this.getConfig('variables')}
-                  unitsConversions={this.getConfig('units')}
-                  active={this.state.tabKey === 'summary'}
-                />
-                <T path='summary.notes.derivedVars'/>
+                {
+                  this.state.tabKey === 'summary' &&
+                  <React.Fragment>
+                    <T path='summary.notes.general' data={{
+                      region: region,
+                      baselineTimePeriod,
+                      futureTimePeriod,
+                      futureDecade: middleDecade(futureTimePeriod),
+                      baselineDecade: middleDecade(baselineTimePeriod),
+                    }}/>
+                    <Summary
+                      region={get('value', this.state.region)}
+                      futureTimePeriod={futureTimePeriod}
+                      tableContents={this.getConfig('summary.table.contents')}
+                      variableConfig={this.getConfig('variables')}
+                      unitsConversions={this.getConfig('units')}
+                    />
+                    <T path='summary.notes.derivedVars'/>
+                  </React.Fragment>
+                }
               </Tab>
 
               <Tab
@@ -239,21 +243,25 @@ export default class App extends Component {
                 className='pt-2'
                 mountOnEnter
               >
-                <Row>
-                  <Col lg={12}>
-                    <T path='impacts.prologue' data={{
-                      region: region,
-                      futureDecade: middleDecade(futureTimePeriod),
-                      baselineDecade: middleDecade(baselineTimePeriod),
-                    }}/>
-                    <ImpactsTab
-                      rulebase={rulebase}
-                      region={get('value', this.state.region)}
-                      futureTimePeriod={futureTimePeriod}
-                      active={this.state.tabKey === 'impacts'}
-                    />
-                  </Col>
-                </Row>
+                {
+                  this.state.tabKey === 'impacts' &&
+                  <React.Fragment>
+                    <Row>
+                      <Col lg={12}>
+                        <T path='impacts.prologue' data={{
+                          region: region,
+                          futureDecade: middleDecade(futureTimePeriod),
+                          baselineDecade: middleDecade(baselineTimePeriod),
+                        }}/>
+                        <ImpactsTab
+                          rulebase={rulebase}
+                          region={get('value', this.state.region)}
+                          futureTimePeriod={futureTimePeriod}
+                        />
+                      </Col>
+                    </Row>
+                  </React.Fragment>
+                }
               </Tab>
 
               {/*
@@ -267,15 +275,17 @@ export default class App extends Component {
                 className='pt-2'
                 mountOnEnter
               >
-                <TwoDataMaps
-                  region={get('value', this.state.region)}
-                  historicalTimePeriod={baselineTimePeriod}
-                  futureTimePeriod={futureTimePeriod}
-                  season={get('value', this.state.season)}
-                  variable={get('value', this.state.variable)}
-                  metadata={this.state.metadata}
-                  active={this.state.tabKey === 'maps'}
-                />
+                {
+                  this.state.tabKey === 'maps' &&
+                  <TwoDataMaps
+                    region={get('value', this.state.region)}
+                    historicalTimePeriod={baselineTimePeriod}
+                    futureTimePeriod={futureTimePeriod}
+                    season={get('value', this.state.season)}
+                    variable={get('value', this.state.variable)}
+                    metadata={this.state.metadata}
+                  />
+                }
               </Tab>
 
               <Tab
@@ -285,32 +295,36 @@ export default class App extends Component {
                 className='pt-2'
                 mountOnEnter
               >
-                <Row>
-                  <Col lg={12}>
-                    <T path='graphs.title' data={{
-                      season: get('label', this.state.season),
-                      variable: get('label', this.state.variable),
-                      region: get('label', this.state.region),
-                    }}/>
-                  </Col>
-                </Row>
-                <Row>
-                  <Col lg={12}>
-                    <ChangeOverTimeGraph
-                      region={get('value', this.state.region)}
-                      historicalTimePeriod={baselineTimePeriod}
-                      season={get('value', this.state.season)}
-                      variable={get('value', this.state.variable)}
-                      // TODO: This may be better obtained from metadata
-                      futureTimePeriods={
-                        this.getConfig('graphs.config.futureTimePeriods')}
-                      graphConfig={this.getConfig('graphs.config')}
-                      variableConfig={this.getConfig('variables')}
-                      unitsConversions={this.getConfig('units')}
-                      active={this.state.tabKey === 'graphs'}
-                    />
-                  </Col>
-                </Row>
+                {
+                  this.state.tabKey === 'graphs' &&
+                  <React.Fragment>
+                    <Row>
+                      <Col lg={12}>
+                        <T path='graphs.title' data={{
+                          season: get('label', this.state.season),
+                          variable: get('label', this.state.variable),
+                          region: get('label', this.state.region),
+                        }}/>
+                      </Col>
+                    </Row>
+                    <Row>
+                      <Col lg={12}>
+                        <ChangeOverTimeGraph
+                          region={get('value', this.state.region)}
+                          historicalTimePeriod={baselineTimePeriod}
+                          season={get('value', this.state.season)}
+                          variable={get('value', this.state.variable)}
+                          // TODO: This may be better obtained from metadata
+                          futureTimePeriods={
+                            this.getConfig('graphs.config.futureTimePeriods')}
+                          graphConfig={this.getConfig('graphs.config')}
+                          variableConfig={this.getConfig('variables')}
+                          unitsConversions={this.getConfig('units')}
+                        />
+                      </Col>
+                    </Row>
+                  </React.Fragment>
+                }
               </Tab>
 
               <Tab

--- a/src/components/app-root/App/App.js
+++ b/src/components/app-root/App/App.js
@@ -250,6 +250,7 @@ export default class App extends Component {
                       rulebase={rulebase}
                       region={get('value', this.state.region)}
                       futureTimePeriod={futureTimePeriod}
+                      active={this.state.tabKey === 'impacts'}
                     />
                   </Col>
                 </Row>

--- a/src/components/app-root/App/App.js
+++ b/src/components/app-root/App/App.js
@@ -307,6 +307,7 @@ export default class App extends Component {
                       graphConfig={this.getConfig('graphs.config')}
                       variableConfig={this.getConfig('variables')}
                       unitsConversions={this.getConfig('units')}
+                      active={this.state.tabKey === 'graphs'}
                     />
                   </Col>
                 </Row>

--- a/src/components/app-root/App/App.js
+++ b/src/components/app-root/App/App.js
@@ -227,6 +227,7 @@ export default class App extends Component {
                   tableContents={this.getConfig('summary.table.contents')}
                   variableConfig={this.getConfig('variables')}
                   unitsConversions={this.getConfig('units')}
+                  active={this.state.tabKey === 'summary'}
                 />
                 <T path='summary.notes.derivedVars'/>
               </Tab>

--- a/src/components/data-displays/Summary/Summary.js
+++ b/src/components/data-displays/Summary/Summary.js
@@ -132,13 +132,6 @@ class Summary extends React.Component {
     //
     // Example value: See configuration file, key 'units'.
     // TODO: Convert this to a more explicit PropType when the layout settles.
-
-    active: PropTypes.bool,
-    // This is a mechanism for achieving two things:
-    // 1. Forcing a re-render when the component becomes "active" (which
-    //  is typically when the tab it is inside is selected).
-    // 2. Not rendering anything when it is inactive, which saves a pile
-    //  of unnecessary updates.
   };
 
   static defaultProps = {
@@ -149,9 +142,6 @@ class Summary extends React.Component {
   };
 
   render() {
-    if (!this.props.active) {
-      return null;
-    }
     if (!allDefined(
       [
         'region.geometry',
@@ -294,8 +284,6 @@ const loadSummaryStatistics = ({region, futureTimePeriod, tableContents}) =>
 
 
 export const shouldLoadSummaryStatistics = (prevProps, props) =>
-  // Component is active
-  props.active &&
   // ... relevant props have settled to defined values
   allDefined(
     [
@@ -310,7 +298,6 @@ export const shouldLoadSummaryStatistics = (prevProps, props) =>
   // between previous and current relevant props
   !(
     prevProps &&
-    isEqual(prevProps.active, props.active) &&
     isEqual(prevProps.region, props.region) &&
     isEqual(prevProps.futureTimePeriod, props.futureTimePeriod) &&
     isEqual(prevProps.tableContents, props.tableContents)

--- a/src/components/data-displays/impacts/ImpactsTab/ImpactsTab.js
+++ b/src/components/data-displays/impacts/ImpactsTab/ImpactsTab.js
@@ -23,19 +23,9 @@ class ImpactsTab extends React.Component {
     region: PropTypes.object.isRequired,
     futureTimePeriod: PropTypes.object.isRequired,
     ruleValues: PropTypes.object.isRequired,
-
-    active: PropTypes.bool,
-    // This is a mechanism for achieving two things:
-    // 1. Forcing a re-render when the component becomes "active" (which
-    //  is typically when the tab it is inside is selected).
-    // 2. Not rendering anything when it is inactive, which saves a pile
-    //  of unnecessary updates.
   };
 
   render() {
-    if (!this.props.active) {
-      return null;
-    }
     if (!allDefined(
       [
         'rulebase',
@@ -47,6 +37,7 @@ class ImpactsTab extends React.Component {
       this.props
     )) {
       console.log('### ImpactsTab: unsettled props', this.props)
+      return <h1>Loading ImpactsTab</h1>
       return <Loader/>
     }
     return (

--- a/src/components/data-displays/impacts/ImpactsTab/ImpactsTab.js
+++ b/src/components/data-displays/impacts/ImpactsTab/ImpactsTab.js
@@ -6,6 +6,8 @@ import Impacts from '../Impacts';
 import Rules from '../Rules';
 import withAsyncData from '../../../../HOCs/withAsyncData';
 import { loadRulesResults, shouldLoadRulesResults } from '../common';
+import { allDefined } from '../../../../utils/lodash-fp-extras';
+import Loader from 'react-loader';
 
 
 class ImpactsTab extends React.Component {
@@ -21,9 +23,32 @@ class ImpactsTab extends React.Component {
     region: PropTypes.object.isRequired,
     futureTimePeriod: PropTypes.object.isRequired,
     ruleValues: PropTypes.object.isRequired,
+
+    active: PropTypes.bool,
+    // This is a mechanism for achieving two things:
+    // 1. Forcing a re-render when the component becomes "active" (which
+    //  is typically when the tab it is inside is selected).
+    // 2. Not rendering anything when it is inactive, which saves a pile
+    //  of unnecessary updates.
   };
 
   render() {
+    if (!this.props.active) {
+      return null;
+    }
+    if (!allDefined(
+      [
+        'rulebase',
+        'region.geometry',
+        'futureTimePeriod.start_date',
+        'futureTimePeriod.end_date',
+        'ruleValues',
+      ],
+      this.props
+    )) {
+      console.log('### ImpactsTab: unsettled props', this.props)
+      return <Loader/>
+    }
     return (
       <Tabs
         id={'impacts'}

--- a/src/components/data-displays/impacts/common.js
+++ b/src/components/data-displays/impacts/common.js
@@ -8,8 +8,6 @@ export const loadRulesResults = props => {
 
 
 export const shouldLoadRulesResults = (prevProps, props) =>
-  // Component is active
-  props.active &&
   // ... relevant props have settled to defined values
   allDefined(
     [
@@ -23,7 +21,6 @@ export const shouldLoadRulesResults = (prevProps, props) =>
   // between previous and current relevant props
   !(
     prevProps &&
-    isEqual(prevProps.active, props.active) &&
     isEqual(prevProps.region, props.region) &&
     isEqual(prevProps.futureTimePeriod, props.futureTimePeriod)
   );

--- a/src/components/data-displays/impacts/common.js
+++ b/src/components/data-displays/impacts/common.js
@@ -1,5 +1,6 @@
 import { fetchRulesResults } from '../../../data-services/rules-engine';
 import isEqual from 'lodash/fp/isEqual';
+import { allDefined } from '../../../utils/lodash-fp-extras';
 
 export const loadRulesResults = props => {
   return fetchRulesResults(props.region, props.futureTimePeriod);
@@ -7,12 +8,22 @@ export const loadRulesResults = props => {
 
 
 export const shouldLoadRulesResults = (prevProps, props) =>
+  // Component is active
+  props.active &&
   // ... relevant props have settled to defined values
-  props.region && props.futureTimePeriod &&
+  allDefined(
+    [
+      'region.geometry',
+      'futureTimePeriod.start_date',
+      'futureTimePeriod.end_date',
+    ],
+    props
+  ) &&
   // ... and there are either no previous props, or there is a difference
   // between previous and current relevant props
   !(
     prevProps &&
+    isEqual(prevProps.active, props.active) &&
     isEqual(prevProps.region, props.region) &&
     isEqual(prevProps.futureTimePeriod, props.futureTimePeriod)
   );

--- a/src/components/graphs/ChangeOverTimeGraph/ChangeOverTimeGraph.js
+++ b/src/components/graphs/ChangeOverTimeGraph/ChangeOverTimeGraph.js
@@ -115,13 +115,6 @@ class ChangeOverTimeGraphDisplay extends React.Component {
     //
     // Example value: See configuration file, key 'units'.
     // TODO: Convert this to a more explicit PropType when the layout settles.
-
-    active: PropTypes.bool,
-    // This is a mechanism for achieving two things:
-    // 1. Forcing a re-render when the component becomes "active" (which
-    //  is typically when the tab it is inside is selected).
-    // 2. Not rendering anything when it is inactive, which saves a pile
-    //  of unnecessary updates.
   };
 
   // TODO: Replace state and state management code with settings from config
@@ -142,9 +135,6 @@ class ChangeOverTimeGraphDisplay extends React.Component {
     pointRadius => this.setState({ pointRadius });
 
   render() {
-    if (!this.props.active) {
-      return null;
-    }
     if (!allDefined(
       [
         'region.geometry',
@@ -349,8 +339,6 @@ const loadSummaryStatistics = ({region, variable, season, futureTimePeriods}) =>
 
 
 export const shouldLoadSummaryStatistics = (prevProps, props) =>
-  // Component is active
-  props.active &&
   // ... relevant props have settled to defined values
   allDefined(
     [
@@ -368,7 +356,6 @@ export const shouldLoadSummaryStatistics = (prevProps, props) =>
   // between previous and current relevant props
   !(
     prevProps &&
-    isEqual(prevProps.active, props.active) &&
     isEqual(prevProps.region, props.region) &&
     isEqual(prevProps.variable, props.variable) &&
     isEqual(prevProps.season, props.season) &&

--- a/src/components/maps/TwoDataMaps/TwoDataMaps.js
+++ b/src/components/maps/TwoDataMaps/TwoDataMaps.js
@@ -51,6 +51,13 @@ export default class TwoDataMaps extends React.Component {
     season: PropTypes.number,
     variable: PropTypes.object,
     metadata: PropTypes.array,
+
+    active: PropTypes.bool,
+    // This is a mechanism for achieving two things:
+    // 1. Forcing a re-render when the component becomes "active" (which
+    //  is typically when the tab it is inside is selected).
+    // 2. Not rendering anything when it is inactive, which saves a pile
+    //  of unnecessary updates.
   };
 
   state = {
@@ -88,6 +95,9 @@ export default class TwoDataMaps extends React.Component {
     this.setState({ bounds: regionBounds(this.props.region)});
 
   render() {
+    if (!this.props.active) {
+      return null;
+    }
     if (!allDefined(
       [
         'region.geometry',

--- a/src/components/maps/TwoDataMaps/TwoDataMaps.js
+++ b/src/components/maps/TwoDataMaps/TwoDataMaps.js
@@ -51,13 +51,6 @@ export default class TwoDataMaps extends React.Component {
     season: PropTypes.number,
     variable: PropTypes.object,
     metadata: PropTypes.array,
-
-    active: PropTypes.bool,
-    // This is a mechanism for achieving two things:
-    // 1. Forcing a re-render when the component becomes "active" (which
-    //  is typically when the tab it is inside is selected).
-    // 2. Not rendering anything when it is inactive, which saves a pile
-    //  of unnecessary updates.
   };
 
   state = {
@@ -95,9 +88,6 @@ export default class TwoDataMaps extends React.Component {
     this.setState({ bounds: regionBounds(this.props.region)});
 
   render() {
-    if (!this.props.active) {
-      return null;
-    }
     if (!allDefined(
       [
         'region.geometry',


### PR DESCRIPTION
Resolves #137 

This fix has the somewhat undesirable effect of forcing the map to be rezoomed to the current region selection after a move away from the Maps tab and back again, even if region has not been changed. I judge this to be minor, but it is not ideal.

This PR also goes some way towards #149, though as I note in that issue it is a bit crude. It is exactly the same change to the other data tabs as for the Maps tab. Where the Maps tab fix is the only known one at the moment, the others can probably be achieved better.

And this PR makes each major component consistent in rendering nothing when its props have not settled. In the past that was hit and miss: some did, some didn't.