### PR TITLE
Fix image build arg

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,10 +2,11 @@ name: Docker Publishing
 
 on:
   push:
-    tags:
-      - '*'
     branches:
       - '*'
+  release:
+    type:
+      - created
 
 jobs:
   docker-publish:
@@ -13,23 +14,16 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
-    - uses: actions/checkout@master
-    - run: git pull --unshallow
-    - name: Get Branch
-      uses: nelonoel/branch-name@v1
-    - name: Get Tag
-      uses: olegtarasov/get-tag@v2
-    - name: Set env vars for build
-      run: |
-        echo ::set-env name=BRANCH::$(echo ${BRANCH_NAME})
-        echo ::set-env name=TAG::$(echo ${GIT_TAG_NAME})
-    - name: Export REACT_APP_VERSION env var
-      run: ./generate-commitish.sh
-    - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
-      with:
-        name: pcic/plan2adapt-v2-frontend
-        username: ${{ secrets.pcicdevops_at_dockerhub_username }}
-        password: ${{ secrets.pcicdevops_at_dockerhub_password }}
-        tags: "${{ env.BRANCH }},${{ env.TAG }}"
-        buildargs: ${REACT_APP_VERSION}
+      - uses: actions/checkout@master
+      - name: Export REACT_APP_VERSION env var
+        run: |
+          git fetch --prune --unshallow
+          echo ::set-env name=REACT_APP_VERSION::"$(git describe --tags --abbrev=0) ($(git rev-parse --abbrev-ref HEAD):$(git log -1 --format=%h))"
+      - name: Publish to Registry
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.pcicdevops_at_dockerhub_username }}
+          password: ${{ secrets.pcicdevops_at_dockerhub_password }}
+          repository: pcic/plan2adapt-v2-frontend
+          tag_with_ref: true
+          build_args: REACT_APP_VERSION=${{ env.REACT_APP_VERSION }}

--- a/generate-commitish.sh
+++ b/generate-commitish.sh
@@ -5,5 +5,4 @@ VERSIONTAG="$(git describe --tags --abbrev=0)"
 BRANCH="$(git rev-parse --abbrev-ref HEAD)"
 COMMITSHA="$(git log -1 --format=%h)"
 
-export REACT_APP_VERSION="$VERSIONTAG ($BRANCH: $COMMITSHA)"
 echo "$VERSIONTAG ($BRANCH: $COMMITSHA)"


### PR DESCRIPTION
This PR resolves #150. 
- Fix issue with build arg not being set properly
- Use official docker builder
- Build on release rather than tag
- Remove side effect from `generate_commitish.sh`

Github actions was having some strange interactions with the script that is meant to set the `REACT_VERSION_APP` env var. I have decided to manually build the var in the action without using the script.  This is (I think) the best workaround since we can still use the script for manual builds if need be.

Here is a look at the output:
```
[nrados@docker-dev01 ~]$ docker image inspect pcic/plan2adapt-v2-frontend:i150-image-build-arg -f '{{.ContainerConfig.Env}} {{.Config.Env}}'
[PATH=/app/node_modules/.bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin NODE_VERSION=10.21.0 YARN_VERSION=1.22.4 REACT_APP_VERSION=1.0.1 (i150-image-build-arg:c935935)] [PATH=/app/node_modules/.bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin NODE_VERSION=10.21.0 YARN_VERSION=1.22.4 REACT_APP_VERSION=1.0.1 (i150-image-build-arg:c935935)]
```

Using the official docker image comes with some changes.  It will automatically detect branch/tag names as use them to tag images.  It will also detect when a trigger is coming from `master` and will tag the image with `latest`.  The only difference from our previous tagging strategy is that PRs will be tagged by the PR number and not the original branch name.  I think this is an acceptable change considering how much easier it is to use this action instead of what was being done previously.

I've also taken this chance to slightly change the trigger strategy.  Instead of triggering on `tags` we will trigger on releases.  It seems this is a more reliable way to go about releasing new versions.