### PR TITLE
Rework image scan triggers

### DIFF
--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -19,9 +19,13 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           checkName: docker-publish
           ref: ${{ github.sha }}
+      - name: Get branch name
+        uses: nelonoel/branch-name@v1
+      - name: Set Branch Name to Environment Variable
+        run: echo ::set-env name=TAG::$(echo ${BRANCH_NAME})
       - name: Scan Image
         uses: anchore/scan-action@master
         with:
-          image-reference: "pcic/plan2adapt-v2-frontend:${{ github.sha }}"
+          image-reference: "pcic/plan2adapt-v2-frontend:${{ env.TAG }}"
           fail-build: true
         if: steps.wait-for-build.outputs.conclusion == 'success'

--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -1,9 +1,10 @@
 name: Image Scan
 
 on:
-  pull_request:
+  push:
     branches:
       - master
+      - '*security*'
 
 jobs:
   anchore:
@@ -17,10 +18,10 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           checkName: docker-publish
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.sha }}
       - name: Scan Image
         uses: anchore/scan-action@master
         with:
-          image-reference: "pcic/plan2adapt-v2-frontend:${{ github.event.pull_request.head.ref }}"
+          image-reference: "pcic/plan2adapt-v2-frontend:${{ github.sha }}"
           fail-build: true
         if: steps.wait-for-build.outputs.conclusion == 'success'

--- a/README.md
+++ b/README.md
@@ -1,30 +1,31 @@
 # Plan2Adapt Version 2
 
 [![Build Status](https://travis-ci.org/pacificclimate/plan2adapt-v2.svg?branch=master)](https://travis-ci.org/pacificclimate/plan2adapt-v2)
+![Image Scan](https://github.com/pacificclimate/plan2adapt-v2/workflows/Image%20Scan/badge.svg?branch=master)
 
 Plan2Adapt Version 2 is an updated and improved version of the original
-[Plan2Adapt v1](https://pacificclimate.org/analysis-tools/plan2adapt) 
+[Plan2Adapt v1](https://pacificclimate.org/analysis-tools/plan2adapt)
 with the following general requirements and goals:
 
 1. Provide a functional superset of Plan2Adapt v1
 1. Drive with CMIP5 data (from CE backend infrastructure)
 1. Improve the user interface
    1. Improved layout and aesthetics (e.g., by adopting Bootstrap)
-   1. Context and context-changing controls (e.g., selectors) always visible 
+   1. Context and context-changing controls (e.g., selectors) always visible
       and immediately accessible, with immediate response.
    1. Improved client-side map (Leaflet)
    1. Interactive graphs (D3/C3 or similar)
    1. Replace overlay "dialogs" for data presentation with tabbed or similar interfaces
-   1. Replace individual map elements per variable 
-      (e.g., Temp, Precip, Snowfall, ...) with a single map view that changes 
-      according to variable selection. 
-   1. Likewise for graphs. 
+   1. Replace individual map elements per variable
+      (e.g., Temp, Precip, Snowfall, ...) with a single map view that changes
+      according to variable selection.
+   1. Likewise for graphs.
    1. Generally similar to the design of the CE interface, but much simplified.
 1. Improve maintainability
    1. Implement with a modern framework (React)
-   1. Use library components wherever possible 
+   1. Use library components wherever possible
       (including pcic-react-components, pcic-react-leaflet-components)
-      
+
 For more information on architecture and design, see
 [Plan2Adapt v2 Architecture and Development Plan](https://pcic.uvic.ca/confluence/display/CSG/Plan2Adapt+v2+Architecture+and+Development+Plan)
 
@@ -50,7 +51,7 @@ docker build -t plan2adapt-v2-frontend \
 
 **IMPORTANT**: Setting the build arg `REACT_APP_VERSION` as above is the most reliable
 way to inject an accurate version id into the final app. This value can be overridden
-when the image is run (by specifying the environment variable of the same name), 
+when the image is run (by specifying the environment variable of the same name),
 but it is not recommended, as it invites error.
 
 #### Tag docker image
@@ -79,7 +80,7 @@ TODO: Ensure this documentation matches the current DevOps process.
 
 #### Push docker image to PCIC docker registry
 
-[PCIC maintains its own docker registry](https://pcic.uvic.ca/confluence/pages/viewpage.action?pageId=3506599). 
+[PCIC maintains its own docker registry](https://pcic.uvic.ca/confluence/pages/viewpage.action?pageId=3506599).
 We place manual builds in this registry:
 
 ```bash
@@ -168,7 +169,7 @@ git push --follow-tags
 
 This project is very text-heavy. We'd rather not release a new version every time we tweak some punctuation,
 so instead of embedding all the text in the app, we externalize it into a resource file and use the (PCIC-developed)
-`pcic-react-external-text` package to provide the text content. `pcic-react-external-text` processes Markdown, 
+`pcic-react-external-text` package to provide the text content. `pcic-react-external-text` processes Markdown,
 so the resource file can contain Markdown for complex content, of which we have quite a bit in this app.
 
 The external text resource file is loaded from the project's
@@ -177,10 +178,10 @@ from a file whose path within that folder is specified by the environment variab
 The present setting for this path is `external-text/default.yaml`.
 
 In a Create React App app (which this is), the
-public folder is outside the module system managed by Webpack, and its contents are transferred to `/build/static` 
-when the app is built (`npm run build`). 
+public folder is outside the module system managed by Webpack, and its contents are transferred to `/build/static`
+when the app is built (`npm run build`).
 Being outside the module system, the content of `/build/static` can be updated at any time,
-meaning that the external texts file can be changed after the application is built and deployed. 
+meaning that the external texts file can be changed after the application is built and deployed.
 The updated external text content will be used whenever the app is refreshed or launched anew after that point.
 
 During development, you can update the external text file and refresh the app to see the effect of the new content.
@@ -188,15 +189,15 @@ During development, you can update the external text file and refresh the app to
 ## Package dependencies security vulnerabilities
 
 Since npm@6, npm has included a tool,
-[`npm audit`](https://blog.npmjs.org/post/173719309445/npm-audit-identify-and-fix-insecure) 
+[`npm audit`](https://blog.npmjs.org/post/173719309445/npm-audit-identify-and-fix-insecure)
 to protect code from known security risks in package dependencies.
 
 `npm audit` runs automatically whenever `npm install` is run, and can also
 be run independently from the command line.
 
-`npm audit` shows, at the time of this writing, 63 low-concern 
+`npm audit` shows, at the time of this writing, 63 low-concern
 vulnerabilities, all due to package `braces`. Given the low concern and the
 nature of the vulnerability, it is not worth addressing at this time.
 
-The output of `npm audit` should be heeded, and if other vulnerabilities 
+The output of `npm audit` should be heeded, and if other vulnerabilities
 are flagged, they should be evaluated and addressed if necessary.


### PR DESCRIPTION
We will now only perform `anchore` image scans when pushing to `master` or while pushing to a branch with `security` as a substring (this has been tested). My IDE automatically took out extra whitespace in the `README.md` but the only actual change was the addition of a badge to relay the status of the scans.

Resolves #164 