### PR TITLE
Use lethargic map scrolling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10897,6 +10897,11 @@
       "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
       "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA=="
     },
+    "lethargy": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/lethargy/-/lethargy-1.0.9.tgz",
+      "integrity": "sha512-nFM8blpCF9rqIL5mRAaTGc78W8oQixVtsD86jbEPvcI13+lDUYJf3R7DZQQL7tCiBpbGpGKMX2gwJFO9hiaOkg=="
+    },
     "leven": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "classnames": "^2.2.6",
     "js-yaml": "^3.13.1",
     "leaflet": "^1.4.0",
+    "lethargy": "^1.0.9",
     "lodash": "^4.17.11",
     "pcic-react-components": "git+https://git@github.com/pacificclimate/pcic-react-components.git#3.1.0",
     "pcic-react-external-text": "git+https://git@github.com/pacificclimate/pcic-react-external-text.git#1.0.0",

--- a/public/external-text/default.yaml
+++ b/public/external-text/default.yaml
@@ -220,6 +220,11 @@ impacts:
 maps:
   disabled: false
   tab: Maps
+  lethargicScrolling:
+    active: true
+    stability: 7
+    sensitivity: 50
+    tolerance: 0.05
   historical:
     title: "#### Historical: ${$$.components.period}"
   projected:

--- a/src/components/app-root/App/App.js
+++ b/src/components/app-root/App/App.js
@@ -31,7 +31,7 @@ import ImpactsTabBody from '../ImpactsTabBody';
 import MapsTabBody from '../MapsTabBody';
 import GraphsTabBody from '../GraphsTabBody';
 import { getVariableLabel } from '../../../utils/variables-and-units';
-import { setLethargicScrolling } from '../../../utils/leaflet-extensions';
+import { setLethargicMapScrolling } from '../../../utils/leaflet-extensions';
 
 const baselineTimePeriod = {
   start_date: 1961,
@@ -84,17 +84,17 @@ export default class App extends Component {
     }
   }
 
-  setLethargicScrolling = () => {
-    // Lethargic scrolling needs to be set, just once, after context updates.
-    // We call this in componentDidMount and componentDidUpdate, and do nothing
-    // except the first time context updates. Sigh.
+  setLethargicMapScrolling = () => {
+    // Lethargic map scrolling needs to be set, just once, after context
+    // updates. We call this in componentDidMount and componentDidUpdate, and do
+    // nothing except the first time context updates. Sigh.
 
     if (!this.state.contextJustUpdated) {
       return;
     }
     const lethargicScrolling = this.getConfig('maps.lethargicScrolling');
     if (lethargicScrolling && lethargicScrolling.active) {
-      setLethargicScrolling(
+      setLethargicMapScrolling(
         lethargicScrolling.stability,
         lethargicScrolling.sensitivity,
         lethargicScrolling.tolerance,
@@ -108,12 +108,12 @@ export default class App extends Component {
       .then(metadata => this.setState({ metadata }));
     // this.setState({ context: this.context });  // ??
     this.trackContextState();
-    this.setLethargicScrolling();
+    this.setLethargicMapScrolling();
   }
 
   componentDidUpdate(prevProps, prevState, snapshot) {
     this.trackContextState();
-    this.setLethargicScrolling();
+    this.setLethargicMapScrolling();
   }
 
   handleChangeSelection = (name, value) => this.setState({ [name]: value });

--- a/src/utils/external-text.js
+++ b/src/utils/external-text.js
@@ -8,12 +8,12 @@ export function makeYamlLoader(url) {
   // argument `setTexts` with the resulting object. Any error thrown during
   // this process is logged to the console (and `setTexts` is not called).
   return function (setTexts) {
-    console.log('YAML loader: loading...')
+    console.log('### YAML loader: loading...')
     axios.get(url, { responseType: 'text' })
     .then(response => response.data)
     .then(yaml.safeLoad)
     .then(data => {
-      console.log('YAML loader: loaded', data);
+      console.log('### YAML loader: loaded', data);
       return data;
     })
     .then(setTexts)

--- a/src/utils/leaflet-extensions.js
+++ b/src/utils/leaflet-extensions.js
@@ -4,9 +4,9 @@ import L from 'leaflet';
 
 // Stop inertial scrolling from interfering with scroll wheel zooming.
 // See https://github.com/Leaflet/Leaflet/issues/4410#issuecomment-340905236
-export const setLethargicScrolling = (...args) => {
+export const setLethargicMapScrolling = (...args) => {
   const lethargy = new Lethargy(...args);
-  console.log('### setLethargicScrolling', lethargy)
+  console.log('### setLethargicMapScrolling', lethargy)
   const isInertialScroll = (e) => lethargy.check(e) === false;
   L.Map.ScrollWheelZoom.prototype._onWheelScroll = function (e) {
     L.DomEvent.stop(e);

--- a/src/utils/leaflet-extensions.js
+++ b/src/utils/leaflet-extensions.js
@@ -1,0 +1,22 @@
+import { Lethargy } from 'lethargy';
+import L from 'leaflet';
+
+
+// Stop inertial scrolling from interfering with scroll wheel zooming.
+// See https://github.com/Leaflet/Leaflet/issues/4410#issuecomment-340905236
+export const setLethargicScrolling = (...args) => {
+  const lethargy = new Lethargy(...args);
+  console.log('### setLethargicScrolling', lethargy)
+  const isInertialScroll = (e) => lethargy.check(e) === false;
+  L.Map.ScrollWheelZoom.prototype._onWheelScroll = function (e) {
+    L.DomEvent.stop(e);
+    if (isInertialScroll(e)) {
+      return;
+    }
+
+    this._delta += L.DomEvent.getWheelDelta(e);
+    this._lastMousePos = this._map.mouseEventToContainerPoint(e);
+    this._performZoom();
+  }
+}
+


### PR DESCRIPTION
Resolves #144 

The underlying problem in #144 appears to be the Magic Mouse and its inertial scrolling. This PR uses the package `lethargy` to filter out inertial scrolling in the maps, i.e., for zooms. Its parameters are set from config.