### PR TITLE
Refactor tabs

### DIFF
--- a/public/external-text/default.yaml
+++ b/public/external-text/default.yaml
@@ -107,10 +107,9 @@ summary:
 impacts:
   disabled: false
   tab: Impacts
-  title: "## Potential Impacts for ${region} in the ${futureTimePeriod}"
   prologue: |
-    Below, you can view a list of potential impacts that may affect ${region}
-    in the ${futureDecade}s.
+    Below, you can view a list of potential impacts that may affect
+    ${region.properties.english_na} in the ${futureDecade}s.
     This is intended to provide a starting point for more detailed local
     assessment of climate change impacts.
     These are based on limited climate change information, as shown in the

--- a/public/external-text/default.yaml
+++ b/public/external-text/default.yaml
@@ -34,7 +34,6 @@ dev-graph:
 summary:
   disabled: false
   tab: Summary
-  title: "## Summary of Climate Change for ${region} in the ${futureTimePeriod}"
   # It's tempting to do this content as a Markdown table, but unfortunately
   # MD doesn't let you span table rows or columns.
   table:
@@ -95,7 +94,7 @@ summary:
       (${baselineTimePeriod.start_date}-${baselineTimePeriod.end_date})
       to the
       ${futureDecade}s (${futureTimePeriod.start_date}-${futureTimePeriod.end_date})
-      for the ${region} region.
+      for the ${region.properties.english_na} region.
       The ensemble median is a mid-point value, chosen from a PCIC standard
       set of Global Climate Model (GCM) projections (see the 'Notes' tab for
       more information).

--- a/src/components/app-root/App/App.js
+++ b/src/components/app-root/App/App.js
@@ -29,6 +29,7 @@ import SummaryTabBody from '../SummaryTabBody';
 import ImpactsTabBody from '../ImpactsTabBody';
 import MapsTabBody from '../MapsTabBody';
 import GraphsTabBody from '../GraphsTabBody';
+import { getVariableLabel } from '../../../utils/variables-and-units';
 
 const baselineTimePeriod = {
   start_date: 1961,
@@ -77,20 +78,9 @@ export default class App extends Component {
     console.log('### Loaded')
     const variableConfig = this.getConfig('variables');
 
-    // TODO: Inline
-    const variableSelectorProps = {
-      bases: this.state.metadata,
-      value: this.state.variableOpt,
-      default: this.getConfig('selectors.variable.default'),
-      onChange: this.handleChangeVariable,
-      getOptionLabel: ({ value: { representative: { variable_id }}}) =>
-        `${variableConfig[variable_id].label}`,
-    };
-    const seasonSelectorProps = {
-      value: this.state.seasonOpt,
-      default: this.getConfig('selectors.season.default'),
-      onChange: this.handleChangeSeason,
-    };
+    const getVariableOptionLabel =
+      ({ value: { representative: { variable_id } } }) =>
+        getVariableLabel(variableConfig, variable_id);
 
     return (
       <Container fluid>
@@ -144,7 +134,11 @@ export default class App extends Component {
                     </Col>
                     <Col xl={12} lg={3} md={4}>
                       <VariableSelector
-                        {...variableSelectorProps}
+                        bases={this.state.metadata}
+                        value={this.state.variableOpt}
+                        default={this.getConfig('selectors.variable.default')}
+                        onChange={this.handleChangeVariable}
+                        getOptionLabel={getVariableOptionLabel}
                       />
                     </Col>
                   </React.Fragment>
@@ -157,7 +151,9 @@ export default class App extends Component {
                     </Col>
                     <Col xl={12} lg={3} md={4}>
                       <SeasonSelector
-                        {...seasonSelectorProps}
+                          value={this.state.seasonOpt}
+                          default={this.getConfig('selectors.season.default')}
+                          onChange={this.handleChangeSeason}
                       />
                     </Col>
                     <Col xl={12} lg={'auto'} md={'auto'} className='pr-0'>

--- a/src/components/app-root/App/App.js
+++ b/src/components/app-root/App/App.js
@@ -50,7 +50,7 @@ export default class App extends Component {
     futureTimePeriod: undefined,
     season: undefined,
     variable: undefined,
-    tabKey: 'summary',
+    tabKey: 'maps',
   };
 
   componentDidMount() {
@@ -253,11 +253,11 @@ export default class App extends Component {
                 {
                   this.state.tabKey === 'maps' &&
                   <MapsTabBody
-                    region={get('value', this.state.region)}
-                    historicalTimePeriod={baselineTimePeriod}
-                    futureTimePeriod={futureTimePeriod}
-                    season={get('value', this.state.season)}
-                    variable={get('value', this.state.variable)}
+                    regionOpt={this.state.region}
+                    futureTimePeriodOpt={this.state.futureTimePeriod}
+                    baselineTimePeriod={baselineTimePeriod}
+                    seasonOpt={this.state.season}
+                    variableOpt={this.state.variable}
                     metadata={this.state.metadata}
                   />
                 }

--- a/src/components/app-root/App/App.js
+++ b/src/components/app-root/App/App.js
@@ -32,6 +32,7 @@ import TwoDataMaps from '../../maps/TwoDataMaps/TwoDataMaps';
 import Cards from '../../misc/Cards';
 import DevColourbar from '../../data-displays/DevColourbar';
 import DevGraph from '../../data-displays/DevGraph';
+import SummaryTabBody from '../SummaryTabBody';
 
 const baselineTimePeriod = {
   start_date: 1961,
@@ -216,23 +217,11 @@ export default class App extends Component {
               >
                 {
                   this.state.tabKey === 'summary' &&
-                  <React.Fragment>
-                    <T path='summary.notes.general' data={{
-                      region: region,
-                      baselineTimePeriod,
-                      futureTimePeriod,
-                      futureDecade: middleDecade(futureTimePeriod),
-                      baselineDecade: middleDecade(baselineTimePeriod),
-                    }}/>
-                    <Summary
-                      region={get('value', this.state.region)}
-                      futureTimePeriod={futureTimePeriod}
-                      tableContents={this.getConfig('summary.table.contents')}
-                      variableConfig={this.getConfig('variables')}
-                      unitsConversions={this.getConfig('units')}
-                    />
-                    <T path='summary.notes.derivedVars'/>
-                  </React.Fragment>
+                  <SummaryTabBody
+                    regionOpt={this.state.region}
+                    futureTimePeriodOpt={this.state.futureTimePeriod}
+                    baselineTimePeriod={baselineTimePeriod}
+                  />
                 }
               </Tab>
 

--- a/src/components/app-root/App/App.js
+++ b/src/components/app-root/App/App.js
@@ -34,6 +34,7 @@ import DevGraph from '../../data-displays/DevGraph';
 import SummaryTabBody from '../SummaryTabBody';
 import ImpactsTabBody from '../ImpactsTabBody';
 import MapsTabBody from '../MapsTabBody';
+import GraphsTabBody from '../GraphsTabBody';
 
 const baselineTimePeriod = {
   start_date: 1961,
@@ -272,33 +273,13 @@ export default class App extends Component {
               >
                 {
                   this.state.tabKey === 'graphs' &&
-                  <React.Fragment>
-                    <Row>
-                      <Col lg={12}>
-                        <T path='graphs.prologue' data={{
-                          season: get('label', this.state.season),
-                          variable: get('label', this.state.variable),
-                          region: get('label', this.state.region),
-                        }}/>
-                      </Col>
-                    </Row>
-                    <Row>
-                      <Col lg={12}>
-                        <ChangeOverTimeGraph
-                          region={get('value', this.state.region)}
-                          historicalTimePeriod={baselineTimePeriod}
-                          season={get('value', this.state.season)}
-                          variable={get('value', this.state.variable)}
-                          // TODO: This may be better obtained from metadata
-                          futureTimePeriods={
-                            this.getConfig('graphs.config.futureTimePeriods')}
-                          graphConfig={this.getConfig('graphs.config')}
-                          variableConfig={this.getConfig('variables')}
-                          unitsConversions={this.getConfig('units')}
-                        />
-                      </Col>
-                    </Row>
-                  </React.Fragment>
+                  <GraphsTabBody
+                    regionOpt={this.state.region}
+                    futureTimePeriodOpt={this.state.futureTimePeriod}
+                    baselineTimePeriod={baselineTimePeriod}
+                    seasonOpt={this.state.season}
+                    variableOpt={this.state.variable}
+                  />
                 }
               </Tab>
 

--- a/src/components/app-root/App/App.js
+++ b/src/components/app-root/App/App.js
@@ -13,8 +13,6 @@ import map from 'lodash/fp/map';
 import includes from 'lodash/fp/includes';
 
 import { fetchSummaryMetadata } from '../../../data-services/metadata';
-import { middleDecade } from '../../../utils/time-periods';
-import rulebase from '../../../assets/rulebase';
 
 import T from '../../../temporary/external-text';
 import AppHeader from '../AppHeader';
@@ -23,10 +21,6 @@ import RegionSelector from '../../selectors/RegionSelector/RegionSelector';
 import TimePeriodSelector from '../../selectors/TimePeriodSelector';
 import SeasonSelector from '../../selectors/SeasonSelector';
 import VariableSelector from '../../selectors/VariableSelector';
-
-import Summary from '../../data-displays/Summary';
-import ChangeOverTimeGraph from '../../graphs/ChangeOverTimeGraph';
-import ImpactsTab from '../../data-displays/impacts/ImpactsTabs';
 
 import Cards from '../../misc/Cards';
 import DevColourbar from '../../data-displays/DevColourbar';
@@ -47,10 +41,10 @@ export default class App extends Component {
 
   state = {
     metadata: null,
-    region: undefined,
-    futureTimePeriod: undefined,
-    season: undefined,
-    variable: undefined,
+    regionOpt: undefined,
+    futureTimePeriodOpt: undefined,
+    seasonOpt: undefined,
+    variableOpt: undefined,
     tabKey: 'maps',
   };
 
@@ -60,13 +54,13 @@ export default class App extends Component {
   }
 
   handleChangeSelection = (name, value) => this.setState({ [name]: value });
-  handleChangeRegion = this.handleChangeSelection.bind(this, 'region');
-  handleChangeTimePeriod = this.handleChangeSelection.bind(this, 'futureTimePeriod');
-  handleChangeSeason = this.handleChangeSelection.bind(this, 'season');
-  handleChangeVariable = this.handleChangeSelection.bind(this, 'variable');
+  handleChangeRegion = this.handleChangeSelection.bind(this, 'regionOpt');
+  handleChangeTimePeriod = this.handleChangeSelection.bind(this, 'futureTimePeriodOpt');
+  handleChangeSeason = this.handleChangeSelection.bind(this, 'seasonOpt');
+  handleChangeVariable = this.handleChangeSelection.bind(this, 'variableOpt');
   handleChangeTab = this.handleChangeSelection.bind(this, 'tabKey');
 
-    selectorEnabled = name =>
+  selectorEnabled = name =>
     includes(this.state.tabKey)(this.getConfig(`selectors.${name}.forTabs`));
 
   render() {
@@ -83,21 +77,17 @@ export default class App extends Component {
     console.log('### Loaded')
     const variableConfig = this.getConfig('variables');
 
-    const futureTimePeriod =
-      get('futureTimePeriod.value.representative', this.state) || {};
-    const region = get('region.label', this.state) || '';
-
     // TODO: Inline
     const variableSelectorProps = {
       bases: this.state.metadata,
-      value: this.state.variable,
+      value: this.state.variableOpt,
       default: this.getConfig('selectors.variable.default'),
       onChange: this.handleChangeVariable,
       getOptionLabel: ({ value: { representative: { variable_id }}}) =>
         `${variableConfig[variable_id].label}`,
     };
     const seasonSelectorProps = {
-      value: this.state.season,
+      value: this.state.seasonOpt,
       default: this.getConfig('selectors.season.default'),
       onChange: this.handleChangeSeason,
     };
@@ -123,7 +113,7 @@ export default class App extends Component {
                     <Col xl={12} lg={3} md={6}>
                       <RegionSelector
                         default={T.get(texts, 'selectors.region.default', {}, 'raw')}
-                        value={this.state.region}
+                        value={this.state.regionOpt}
                         onChange={this.handleChangeRegion}
                       />
                     </Col>
@@ -138,7 +128,7 @@ export default class App extends Component {
                     <Col xl={12} lg={3} md={4}>
                       <TimePeriodSelector
                         bases={filter(m => +m.start_date >= 2010)(this.state.metadata)}
-                        value={this.state.futureTimePeriod}
+                        value={this.state.futureTimePeriodOpt}
                         default={T.get(texts, 'selectors.timePeriod.default', {}, 'raw')}
                         onChange={this.handleChangeTimePeriod}
                         debug
@@ -204,8 +194,8 @@ export default class App extends Component {
                 mountOnEnter
               >
                 <DevColourbar
-                  season={get('value', this.state.season)}
-                  variable={get('value', this.state.variable)}
+                  season={get('value', this.state.seasonOpt)}
+                  variable={get('value', this.state.variableOpt)}
                 />
               </Tab>
               }
@@ -220,8 +210,8 @@ export default class App extends Component {
                 {
                   this.state.tabKey === 'summary' &&
                   <SummaryTabBody
-                    regionOpt={this.state.region}
-                    futureTimePeriodOpt={this.state.futureTimePeriod}
+                    regionOpt={this.state.regionOpt}
+                    futureTimePeriodOpt={this.state.futureTimePeriodOpt}
                     baselineTimePeriod={baselineTimePeriod}
                   />
                 }
@@ -237,8 +227,8 @@ export default class App extends Component {
                 {
                   this.state.tabKey === 'impacts' &&
                   <ImpactsTabBody
-                    regionOpt={this.state.region}
-                    futureTimePeriodOpt={this.state.futureTimePeriod}
+                    regionOpt={this.state.regionOpt}
+                    futureTimePeriodOpt={this.state.futureTimePeriodOpt}
                     baselineTimePeriod={baselineTimePeriod}
                   />
                 }
@@ -254,11 +244,11 @@ export default class App extends Component {
                 {
                   this.state.tabKey === 'maps' &&
                   <MapsTabBody
-                    regionOpt={this.state.region}
-                    futureTimePeriodOpt={this.state.futureTimePeriod}
+                    regionOpt={this.state.regionOpt}
+                    futureTimePeriodOpt={this.state.futureTimePeriodOpt}
                     baselineTimePeriod={baselineTimePeriod}
-                    seasonOpt={this.state.season}
-                    variableOpt={this.state.variable}
+                    seasonOpt={this.state.seasonOpt}
+                    variableOpt={this.state.variableOpt}
                     metadata={this.state.metadata}
                   />
                 }
@@ -274,11 +264,11 @@ export default class App extends Component {
                 {
                   this.state.tabKey === 'graphs' &&
                   <GraphsTabBody
-                    regionOpt={this.state.region}
-                    futureTimePeriodOpt={this.state.futureTimePeriod}
+                    regionOpt={this.state.regionOpt}
+                    futureTimePeriodOpt={this.state.futureTimePeriodOpt}
                     baselineTimePeriod={baselineTimePeriod}
-                    seasonOpt={this.state.season}
-                    variableOpt={this.state.variable}
+                    seasonOpt={this.state.seasonOpt}
+                    variableOpt={this.state.variableOpt}
                   />
                 }
               </Tab>

--- a/src/components/app-root/App/App.js
+++ b/src/components/app-root/App/App.js
@@ -26,13 +26,14 @@ import VariableSelector from '../../selectors/VariableSelector';
 
 import Summary from '../../data-displays/Summary';
 import ChangeOverTimeGraph from '../../graphs/ChangeOverTimeGraph';
-import ImpactsTab from '../../data-displays/impacts/ImpactsTab';
+import ImpactsTab from '../../data-displays/impacts/ImpactsTabs';
 import TwoDataMaps from '../../maps/TwoDataMaps/TwoDataMaps';
 
 import Cards from '../../misc/Cards';
 import DevColourbar from '../../data-displays/DevColourbar';
 import DevGraph from '../../data-displays/DevGraph';
 import SummaryTabBody from '../SummaryTabBody';
+import ImpactsTabBody from '../ImpactsTabBody';
 
 const baselineTimePeriod = {
   start_date: 1961,
@@ -234,22 +235,11 @@ export default class App extends Component {
               >
                 {
                   this.state.tabKey === 'impacts' &&
-                  <React.Fragment>
-                    <Row>
-                      <Col lg={12}>
-                        <T path='impacts.prologue' data={{
-                          region: region,
-                          futureDecade: middleDecade(futureTimePeriod),
-                          baselineDecade: middleDecade(baselineTimePeriod),
-                        }}/>
-                        <ImpactsTab
-                          rulebase={rulebase}
-                          region={get('value', this.state.region)}
-                          futureTimePeriod={futureTimePeriod}
-                        />
-                      </Col>
-                    </Row>
-                  </React.Fragment>
+                  <ImpactsTabBody
+                    regionOpt={this.state.region}
+                    futureTimePeriodOpt={this.state.futureTimePeriod}
+                    baselineTimePeriod={baselineTimePeriod}
+                  />
                 }
               </Tab>
 

--- a/src/components/app-root/App/App.js
+++ b/src/components/app-root/App/App.js
@@ -27,13 +27,13 @@ import VariableSelector from '../../selectors/VariableSelector';
 import Summary from '../../data-displays/Summary';
 import ChangeOverTimeGraph from '../../graphs/ChangeOverTimeGraph';
 import ImpactsTab from '../../data-displays/impacts/ImpactsTabs';
-import TwoDataMaps from '../../maps/TwoDataMaps/TwoDataMaps';
 
 import Cards from '../../misc/Cards';
 import DevColourbar from '../../data-displays/DevColourbar';
 import DevGraph from '../../data-displays/DevGraph';
 import SummaryTabBody from '../SummaryTabBody';
 import ImpactsTabBody from '../ImpactsTabBody';
+import MapsTabBody from '../MapsTabBody';
 
 const baselineTimePeriod = {
   start_date: 1961,
@@ -243,10 +243,6 @@ export default class App extends Component {
                 }
               </Tab>
 
-              {/*
-              <Tab mountOnEnter> prevents premature initialization of
-              maps leading to incorrect appearance until window is resized.
-              */}
               <Tab
                 eventKey={'maps'}
                 title={<T as='string' path='maps.tab'/>}
@@ -256,7 +252,7 @@ export default class App extends Component {
               >
                 {
                   this.state.tabKey === 'maps' &&
-                  <TwoDataMaps
+                  <MapsTabBody
                     region={get('value', this.state.region)}
                     historicalTimePeriod={baselineTimePeriod}
                     futureTimePeriod={futureTimePeriod}

--- a/src/components/app-root/GraphsTabBody.js
+++ b/src/components/app-root/GraphsTabBody.js
@@ -1,0 +1,77 @@
+// This component creates the content of the Graphs tab.
+// It is responsible for
+//  - Filtering out unsettled props (options from App)
+//  - Layout and formatting
+//  - Marshalling data for subsidiary components
+
+import React from 'react';
+import T from '../../temporary/external-text';
+import { allDefined } from '../../utils/lodash-fp-extras';
+import Loader from 'react-loader';
+import PropTypes from 'prop-types';
+import Row from 'react-bootstrap/Row';
+import Col from 'react-bootstrap/Col';
+import get from 'lodash/fp/get';
+import ChangeOverTimeGraph from '../graphs/ChangeOverTimeGraph';
+
+export default class GraphsTabBody extends React.Component {
+  static contextType = T.contextType;
+  getConfig = path => T.get(this.context, path, {}, 'raw');
+
+  static propTypes = {
+    regionOpt: PropTypes.object,
+    baselineTimePeriod: PropTypes.object,
+    variableOpt: PropTypes.object,
+    seasonOpt: PropTypes.object,
+  };
+
+  render() {
+    if (!allDefined(
+      [
+        'regionOpt',
+        'baselineTimePeriod',
+        'variableOpt',
+        'seasonOpt',
+      ],
+      this.props
+    )) {
+      console.log('### GraphsTabBody: unsettled props', this.props)
+      return <Loader/>
+    }
+
+    const region = this.props.regionOpt.value;
+    const baselineTimePeriod = this.props.baselineTimePeriod;
+    const season = this.props.seasonOpt.value;
+    const variable = this.props.variableOpt.value;
+
+    return (
+      <React.Fragment>
+        <Row>
+          <Col lg={12}>
+            <T path='graphs.prologue' data={{
+              season: get('label', this.props.seasonOpt),
+              variable: get('label', this.props.variableOpt),
+              region: get('label', this.props.regionOpt),
+            }}/>
+          </Col>
+        </Row>
+        <Row>
+          <Col lg={12}>
+            <ChangeOverTimeGraph
+              region={region}
+              baselineTimePeriod={baselineTimePeriod}
+              season={season}
+              variable={variable}
+              // TODO: This may be better obtained from metadata
+              futureTimePeriods={
+                this.getConfig('graphs.config.futureTimePeriods')}
+              graphConfig={this.getConfig('graphs.config')}
+              variableConfig={this.getConfig('variables')}
+              unitsConversions={this.getConfig('units')}
+            />
+          </Col>
+        </Row>
+      </React.Fragment>
+    );
+  }
+}

--- a/src/components/app-root/ImpactsTabBody.js
+++ b/src/components/app-root/ImpactsTabBody.js
@@ -1,0 +1,64 @@
+// This component creates the content of the Impacts tab.
+// It is responsible for
+//  - Filtering out unsettled props (options from App)
+//  - Layout and formatting
+//  - Marshalling data for subsidiary components
+
+import React from 'react';
+import T from '../../temporary/external-text';
+import { middleDecade } from '../../utils/time-periods';
+import { allDefined } from '../../utils/lodash-fp-extras';
+import Loader from 'react-loader';
+import PropTypes from 'prop-types';
+import Row from 'react-bootstrap/Row';
+import Col from 'react-bootstrap/Col';
+import ImpactsTabs from '../data-displays/impacts/ImpactsTabs';
+import rulebase from '../../assets/rulebase';
+
+export default class ImpactsTabBody extends React.Component {
+  static contextType = T.contextType;
+  getConfig = path => T.get(this.context, path, {}, 'raw');
+
+  static propTypes = {
+    regionOpt: PropTypes.object,
+    futureTimePeriodOpt: PropTypes.object,
+    baselineTimePeriod: PropTypes.object,
+  };
+
+  render() {
+    if (!allDefined(
+      [
+        'regionOpt',
+        'futureTimePeriodOpt',
+        'baselineTimePeriod',
+      ],
+      this.props
+    )) {
+      console.log('### ImpactsTabBody: unsettled props', this.props)
+      return <Loader/>
+    }
+
+    const region = this.props.regionOpt.value;
+    const futureTimePeriod = this.props.futureTimePeriodOpt.value.representative;
+    const baselineTimePeriod = this.props.baselineTimePeriod;
+
+    return (
+      <React.Fragment>
+        <Row>
+          <Col lg={12}>
+            <T path='impacts.prologue' data={{
+              region,
+              futureDecade: middleDecade(futureTimePeriod),
+              baselineDecade: middleDecade(baselineTimePeriod),
+            }}/>
+            <ImpactsTabs
+              rulebase={rulebase}
+              region={region}
+              futureTimePeriod={futureTimePeriod}
+            />
+          </Col>
+        </Row>
+      </React.Fragment>
+    );
+  }
+}

--- a/src/components/app-root/MapsTabBody/MapsTabBody.js
+++ b/src/components/app-root/MapsTabBody/MapsTabBody.js
@@ -1,3 +1,9 @@
+// This component creates the content of the Maps tab.
+// It is responsible for
+//  - Filtering out unsettled props (options from App)
+//  - Layout and formatting
+//  - Marshalling data for subsidiary components
+//
 // This component renders two `DataMap`s, one with a baseline climate layer
 // and one with a user-selected climate layer. Map viewports are coordinated.
 // That is, when one map's viewport is changed (panned, zoomed), the other
@@ -24,8 +30,6 @@
 // a better user experience simply to have the other viewport updated once
 // at the end of changing.
 
-// foo
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Row, Col } from 'react-bootstrap';
@@ -47,16 +51,16 @@ export default class MapsTabBody extends React.Component {
   getConfig = path => T.get(this.context, path, {}, 'raw');
 
   static propTypes = {
-    region: PropTypes.string,
-    historicalTimePeriod: PropTypes.object,
-    futureTimePeriod: PropTypes.object,
-    season: PropTypes.number,
-    variable: PropTypes.object,
+    regionOpt: PropTypes.string,
+    baselineTimePeriod: PropTypes.object,
+    futureTimePeriodOpt: PropTypes.object,
+    seasonOpt: PropTypes.number,
+    variableOpt: PropTypes.object,
     metadata: PropTypes.array,
   };
 
   state = {
-    prevPropsRegion: undefined,
+    prevPropsRegionOpt: undefined,
     bounds: undefined,
     viewport: BCBaseMap.initialViewport,
     popup: {
@@ -69,10 +73,10 @@ export default class MapsTabBody extends React.Component {
     // bounding box of the region. We are fortunate that when bounds change,
     // they override the current viewport, and vice-versa, eliminating any
     // need for logic around this on our part.
-    if (props.region !== state.prevPropsRegion) {
+    if (props.regionOpt !== state.prevPropsRegionOpt) {
       return {
-        prevPropsRegion: props.region,
-        bounds: regionBounds(props.region),
+        prevPropsRegionOpt: props.regionOpt,
+        bounds: regionBounds(props.regionOpt.value),
       }
     }
     return null;
@@ -92,25 +96,29 @@ export default class MapsTabBody extends React.Component {
   render() {
     if (!allDefined(
       [
-        'region.geometry',
-        'historicalTimePeriod.start_date',
-        'historicalTimePeriod.end_date',
-        'futureTimePeriod.start_date',
-        'futureTimePeriod.end_date',
-        'variable.representative',
-        'season',
+        'regionOpt',
+        'baselineTimePeriod',
+        'futureTimePeriodOpt',
+        'variableOpt',
+        'seasonOpt',
       ],
       this.props
     )) {
-      console.log('### TwoDataMaps: unsettled props', this.props)
-      return <Loader/>
+      console.log('### MapsTabBody: unsettled props', this.props)
+      return <Loader/>;
     }
-    console.log('### TwoDataMaps: props', this.props)
-    const variableSpec = this.props.variable.representative;
-    const variable = variableSpec.variable_id;
+    console.log('### MapsTabBody: props', this.props)
+    const region = this.props.regionOpt.value;
+    const futureTimePeriod = this.props.futureTimePeriodOpt.value.representative;
+    const baselineTimePeriod = this.props.baselineTimePeriod;
+    const season = this.props.seasonOpt.value;
+    const variable = this.props.variableOpt.value;
+
+    const variableRep = variable.representative;
+    const variableId = variableRep.variable_id;
     const variableConfig = this.getConfig('variables');
     const displaySpec = this.getConfig('maps.displaySpec');
-    const logscale = wmsLogscale(displaySpec, variableSpec);
+    const logscale = wmsLogscale(displaySpec, variableRep);
     const zoomButton = (
       <StaticControl position='topright'>
         <Button
@@ -133,7 +141,7 @@ export default class MapsTabBody extends React.Component {
               length={80}
               heading={<T
                 path='colourScale.label'
-                data={getVariableInfo(variableConfig, variable, 'absolute')}
+                data={getVariableInfo(variableConfig, variableId, 'absolute')}
                 placeholder={null}
                 className={styles.label}
               />}
@@ -143,7 +151,7 @@ export default class MapsTabBody extends React.Component {
                 className={styles.note}
                 data={{ logscale }}
               />}
-              variableSpec={variableSpec}
+              variableSpec={variableRep}
               displaySpec={displaySpec}
             />
           </Col>
@@ -151,8 +159,8 @@ export default class MapsTabBody extends React.Component {
         <Row>
           <Col lg={6}>
             <T path='maps.historical.title' data={{
-              start_date: this.props.historicalTimePeriod.start_date,
-              end_date: this.props.historicalTimePeriod.end_date
+              start_date: this.props.baselineTimePeriod.start_date,
+              end_date: this.props.baselineTimePeriod.end_date
             }}/>
             <DataMap
               id={'historical'}
@@ -161,10 +169,10 @@ export default class MapsTabBody extends React.Component {
               onViewportChanged={this.handleChangeViewport}
               popup={this.state.popup}
               onPopupChange={this.handleChangePopup}
-              region={this.props.region}
-              season={this.props.season}
-              variable={this.props.variable}
-              timePeriod={this.props.historicalTimePeriod}
+              region={region}
+              season={season}
+              variable={variable}
+              timePeriod={baselineTimePeriod}
               metadata={this.props.metadata}
             >
               {zoomButton}
@@ -172,8 +180,8 @@ export default class MapsTabBody extends React.Component {
           </Col>
           <Col lg={6}>
             <T path='maps.projected.title' data={{
-              start_date: this.props.futureTimePeriod.start_date,
-              end_date: this.props.futureTimePeriod.end_date
+              start_date: futureTimePeriod.start_date,
+              end_date: futureTimePeriod.end_date
             }}/>
             <DataMap
               id={'projected'}
@@ -182,10 +190,10 @@ export default class MapsTabBody extends React.Component {
               onViewportChanged={this.handleChangeViewport}
               popup={this.state.popup}
               onPopupChange={this.handleChangePopup}
-              region={this.props.region}
-              season={this.props.season}
-              variable={this.props.variable}
-              timePeriod={this.props.futureTimePeriod}
+              region={region}
+              season={season}
+              variable={variable}
+              timePeriod={futureTimePeriod}
               metadata={this.props.metadata}
             >
               {zoomButton}

--- a/src/components/app-root/MapsTabBody/MapsTabBody.js
+++ b/src/components/app-root/MapsTabBody/MapsTabBody.js
@@ -24,23 +24,25 @@
 // a better user experience simply to have the other viewport updated once
 // at the end of changing.
 
+// foo
+
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Row, Col } from 'react-bootstrap';
 import Loader from 'react-loader';
 import T from '../../../temporary/external-text';
 import DataMap from '../../maps/DataMap';
-import BCBaseMap from '../BCBaseMap';
-import NcwmsColourbar from '../NcwmsColourbar';
-import { regionBounds, wmsLogscale } from '../map-utils';
-import styles from '../NcwmsColourbar/NcwmsColourbar.module.css';
+import BCBaseMap from '../../maps/BCBaseMap';
+import NcwmsColourbar from '../../maps/NcwmsColourbar';
+import { regionBounds, wmsLogscale } from '../../maps/map-utils';
+import styles from '../../maps/NcwmsColourbar/NcwmsColourbar.module.css';
 import { getVariableInfo, } from '../../../utils/variables-and-units';
 import Button from 'react-bootstrap/Button';
-import StaticControl from '../StaticControl';
+import StaticControl from '../../maps/StaticControl';
 import { allDefined } from '../../../utils/lodash-fp-extras';
 
 
-export default class TwoDataMaps extends React.Component {
+export default class MapsTabBody extends React.Component {
   static contextType = T.contextType;
   getConfig = path => T.get(this.context, path, {}, 'raw');
 

--- a/src/components/app-root/MapsTabBody/package.json
+++ b/src/components/app-root/MapsTabBody/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "MapsTabBody",
+  "version": "0.0.0",
+  "private": true,
+  "main": "./MapsTabBody.js"
+}

--- a/src/components/app-root/SummaryTabBody.js
+++ b/src/components/app-root/SummaryTabBody.js
@@ -1,0 +1,62 @@
+// This component creates the content of the Summary tab.
+// It is responsible for
+//  - Filtering out unsettled props (options from App)
+//  - Layout and formatting
+//  - Marshalling data for subsidiary components
+
+import React from 'react';
+import T from '../../temporary/external-text';
+import { middleDecade } from '../../utils/time-periods';
+import Summary from '../data-displays/Summary';
+import { allDefined } from '../../utils/lodash-fp-extras';
+import Loader from 'react-loader';
+import PropTypes from 'prop-types';
+
+export default class SummaryTabBody extends React.Component {
+  static contextType = T.contextType;
+  getConfig = path => T.get(this.context, path, {}, 'raw');
+
+  static propTypes = {
+    regionOpt: PropTypes.object,
+    futureTimePeriodOpt: PropTypes.object,
+    baselineTimePeriod: PropTypes.object,
+  };
+
+  render() {
+    if (!allDefined(
+      [
+        'regionOpt',
+        'futureTimePeriodOpt',
+        'baselineTimePeriod',
+      ],
+      this.props
+    )) {
+      console.log('### SummaryTabBody: unsettled props', this.props)
+      return <Loader/>
+    }
+
+    const region = this.props.regionOpt.value;
+    const futureTimePeriod = this.props.futureTimePeriodOpt.value.representative;
+    const baselineTimePeriod = this.props.baselineTimePeriod;
+
+    return (
+      <React.Fragment>
+        <T path='summary.notes.general' data={{
+          region,
+          baselineTimePeriod,
+          futureTimePeriod,
+          futureDecade: middleDecade(futureTimePeriod),
+          baselineDecade: middleDecade(baselineTimePeriod),
+        }}/>
+        <Summary
+          region={region}
+          futureTimePeriod={futureTimePeriod}
+          tableContents={this.getConfig('summary.table.contents')}
+          variableConfig={this.getConfig('variables')}
+          unitsConversions={this.getConfig('units')}
+        />
+        <T path='summary.notes.derivedVars'/>
+      </React.Fragment>
+    );
+  }
+}

--- a/src/components/data-displays/Summary/Summary.js
+++ b/src/components/data-displays/Summary/Summary.js
@@ -61,7 +61,7 @@ class Summary extends React.Component {
   static propTypes = {
     region: PropTypes.object.isRequired,
     futureTimePeriod: PropTypes.object.isRequired,
-    baseline: PropTypes.object,
+    baselineTimePeriod: PropTypes.object,
 
     tableContents: PropTypes.array.isRequired,
     // Abstract specification of the summary table. Data is implicit in the
@@ -135,7 +135,7 @@ class Summary extends React.Component {
   };
 
   static defaultProps = {
-    baseline: {
+    baselineTimePeriod: {
       start_date: 1961,
       end_date: 1990,
     },
@@ -144,11 +144,9 @@ class Summary extends React.Component {
   render() {
     if (!allDefined(
       [
-        'region.geometry',
-        'baseline.start_date',
-        'baseline.end_date',
-        'futureTimePeriod.start_date',
-        'futureTimePeriod.end_date',
+        'region',
+        'baselineTimePeriod',
+        'futureTimePeriod',
         'tableContents',
         'variableConfig',
         'unitsConversions',
@@ -171,7 +169,7 @@ class Summary extends React.Component {
           </th>
           <th colSpan={2} className='text-center'>
             <T path='summary.table.heading.projectedChange'
-               data={this.props.baseline} as='string'/>
+               data={this.props.baselineTimePeriod} as='string'/>
           </th>
         </tr>
         <tr>

--- a/src/components/data-displays/impacts/ImpactsTab/package.json
+++ b/src/components/data-displays/impacts/ImpactsTab/package.json
@@ -1,6 +1,0 @@
-{
-  "name": "ImpactsTab",
-  "version": "0.0.0",
-  "private": true,
-  "main": "./ImpactsTab.js"
-}

--- a/src/components/data-displays/impacts/ImpactsTabs/ImpactsTabs.js
+++ b/src/components/data-displays/impacts/ImpactsTabs/ImpactsTabs.js
@@ -10,9 +10,9 @@ import { allDefined } from '../../../../utils/lodash-fp-extras';
 import Loader from 'react-loader';
 
 
-class ImpactsTab extends React.Component {
+class ImpactsTabs extends React.Component {
   // This is a pure (state-free), controlled component that renders the entire
-  // content of ImpactsTab.
+  // content of ImpactsTabs.
   //
   // This component is wrapped with `withAsyncData` to inject the rule values
   // (prop `ruleValues`) that are fetched asynchronously, according to the
@@ -29,16 +29,14 @@ class ImpactsTab extends React.Component {
     if (!allDefined(
       [
         'rulebase',
-        'region.geometry',
-        'futureTimePeriod.start_date',
-        'futureTimePeriod.end_date',
+        'region',
+        'futureTimePeriod',
         'ruleValues',
       ],
       this.props
     )) {
-      console.log('### ImpactsTab: unsettled props', this.props)
-      return <h1>Loading ImpactsTab</h1>
-      return <Loader/>
+      console.log('### ImpactsTabs: unsettled props', this.props)
+      return <Loader/>;
     }
     return (
       <Tabs
@@ -89,4 +87,4 @@ class ImpactsTab extends React.Component {
 
 export default withAsyncData(
   loadRulesResults, shouldLoadRulesResults, 'ruleValues'
-)(ImpactsTab);
+)(ImpactsTabs);

--- a/src/components/data-displays/impacts/ImpactsTabs/package.json
+++ b/src/components/data-displays/impacts/ImpactsTabs/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "ImpactsTabs",
+  "version": "0.0.0",
+  "private": true,
+  "main": "./ImpactsTabs.js"
+}

--- a/src/components/graphs/BarChart.js
+++ b/src/components/graphs/BarChart.js
@@ -33,7 +33,7 @@ const transpose = zipAll;
 
 export default class BarChart extends React.Component {
   static propTypes = {
-    historicalTimePeriod: PropTypes.object.isRequired,
+    baselineTimePeriod: PropTypes.object.isRequired,
     // The time period of the historical baseline dataset.
 
     futureTimePeriods: PropTypes.array.isRequired,
@@ -56,7 +56,7 @@ export default class BarChart extends React.Component {
 
   render() {
     const {
-      historicalTimePeriod, futureTimePeriods,
+      baselineTimePeriod, futureTimePeriods,
       graphConfig, variableInfo,
       percentiles, percentileValuesByTimePeriod,
     } = this.props;
@@ -103,7 +103,7 @@ export default class BarChart extends React.Component {
     // organizing the computations is a bit complicated. Hence all the
     // comments below describing the intermediate computations.
 
-    const historicalMiddleYear = middleYear(historicalTimePeriod);
+    const historicalMiddleYear = middleYear(baselineTimePeriod);
     const futureMiddleYears = map(middleYear)(futureTimePeriods);
 
     //  baseTimes: [t0, t1, ... ]
@@ -361,7 +361,7 @@ export default class BarChart extends React.Component {
             start: Number(tp.start_date),
             end: Number(tp.end_date),
             class: index ? styles.projected : styles.baseline,
-          }))(concatAll([historicalTimePeriod, futureTimePeriods])),
+          }))(concatAll([baselineTimePeriod, futureTimePeriods])),
       },
 
       graphConfig.c3options,

--- a/src/components/graphs/ChangeOverTimeGraph/ChangeOverTimeGraph.js
+++ b/src/components/graphs/ChangeOverTimeGraph/ChangeOverTimeGraph.js
@@ -39,7 +39,7 @@ class ChangeOverTimeGraphDisplay extends React.Component {
     season: PropTypes.any,
     variable: PropTypes.any,
 
-    historicalTimePeriod: PropTypes.object.isRequired,
+    baselineTimePeriod: PropTypes.object.isRequired,
     // The time period of the historical baseline dataset.
 
     futureTimePeriods: PropTypes.array.isRequired,
@@ -101,13 +101,11 @@ class ChangeOverTimeGraphDisplay extends React.Component {
   render() {
     if (!allDefined(
       [
-        'region.geometry',
+        'region',
         'season',
-        'variable.representative',
-        'historicalTimePeriod.start_date',
-        'historicalTimePeriod.end_date',
-        'futureTimePeriods[0].start_date',
-        'futureTimePeriods[0].end_date',
+        'variable',
+        'baselineTimePeriod',
+        'futureTimePeriods[0]',
         'statistics',
         'graphConfig',
         'variableConfig',
@@ -120,7 +118,7 @@ class ChangeOverTimeGraphDisplay extends React.Component {
     }
     const {
       variable,
-      historicalTimePeriod, futureTimePeriods, statistics,
+      baselineTimePeriod, futureTimePeriods, statistics,
       graphConfig, variableConfig, unitsConversions,
     } = this.props;
     console.log('### COTG.render: statistics', statistics)
@@ -175,7 +173,7 @@ class ChangeOverTimeGraphDisplay extends React.Component {
     return (
       <React.Fragment>
         <BarChart
-          historicalTimePeriod={historicalTimePeriod}
+          baselineTimePeriod={baselineTimePeriod}
           futureTimePeriods={futureTimePeriods}
           graphConfig={graphConfig}
           variableInfo={variableInfo}
@@ -230,14 +228,12 @@ export const shouldLoadSummaryStatistics = (prevProps, props) =>
   // ... relevant props have settled to defined values
   allDefined(
     [
-      'region.geometry',
+      'region',
       'season',
-      'variable.representative',
-      'historicalTimePeriod.start_date',
-      'historicalTimePeriod.end_date',
-      'futureTimePeriods[0].start_date',
-      'futureTimePeriods[0].end_date',
-      'graphConfig.variables',
+      'variable',
+      'baselineTimePeriod',
+      'futureTimePeriods[0]',
+      'graphConfig',
     ],
     props
   ) &&
@@ -248,7 +244,7 @@ export const shouldLoadSummaryStatistics = (prevProps, props) =>
     isEqual(prevProps.region, props.region) &&
     isEqual(prevProps.variable, props.variable) &&
     isEqual(prevProps.season, props.season) &&
-    isEqual(prevProps.historicalTimePeriod, props.historicalTimePeriod) &&
+    isEqual(prevProps.baselineTimePeriod, props.baselineTimePeriod) &&
     isEqual(prevProps.futureTimePeriods, props.futureTimePeriods)
   );
 

--- a/src/components/maps/DataMap/DataMap.js
+++ b/src/components/maps/DataMap/DataMap.js
@@ -113,6 +113,18 @@ class DataMapDisplay extends React.Component {
   });
 
   render() {
+    if (!allDefined(
+      [
+        'region',
+        'timePeriod',
+        'variable',
+        'season',
+      ],
+      this.props
+    )) {
+      console.log('### DataMap: unsettled props', this.props)
+      return <Loader/>;
+    }
     const {
       children, region, timePeriod, season, variable, popup,
       fileMetadata, ...rest
@@ -198,12 +210,11 @@ const shouldLoadFileMetadata = (prevProps, props) =>
       // For an unknown reason, timePeriod can transiently be {}, which
       // is not valid and causes errors in loading the metadata. So check
       // its innards.
-      'timePeriod.start_date',
-      'timePeriod.end_date',
+      'timePeriod',
       // season is an integer
       'season',
       // Let's check that variable isn't just {} either.
-      'variable.representative',
+      'variable',
     ],
     props
   ) &&

--- a/src/components/maps/DataMap/DataMap.js
+++ b/src/components/maps/DataMap/DataMap.js
@@ -207,13 +207,8 @@ const shouldLoadFileMetadata = (prevProps, props) =>
   // ... relevant props have settled to defined values
   allDefined(
     [
-      // For an unknown reason, timePeriod can transiently be {}, which
-      // is not valid and causes errors in loading the metadata. So check
-      // its innards.
       'timePeriod',
-      // season is an integer
       'season',
-      // Let's check that variable isn't just {} either.
       'variable',
     ],
     props

--- a/src/components/maps/TwoDataMaps/package.json
+++ b/src/components/maps/TwoDataMaps/package.json
@@ -1,6 +1,0 @@
-{
-  "name": "TwoDataMaps",
-  "version": "0.0.0",
-  "private": true,
-  "main": "./TwoDataMaps.js"
-}


### PR DESCRIPTION
This PR refactors App to place top level tab content generation in a single component per tab, with a uniform interface to each one. This addresses a set of inconsistencies in naming and organization that have recently gone from tolerable to problematic.

Addresses #37 