### PR TITLE
Improve map redraws

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8358,6 +8358,11 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
       "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
     },
+    "get-node-dimensions": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/get-node-dimensions/-/get-node-dimensions-1.2.1.tgz",
+      "integrity": "sha512-2MSPMu7S1iOTL+BOa6K1S62hB2zUAYNF/lV0gSVlOaacd087lc6nR1H1r0e3B1CerTo+RceOmi1iJW+vp21xcQ=="
+    },
     "get-own-enumerable-property-symbols": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.0.tgz",
@@ -15462,6 +15467,17 @@
         "xtend": "^4.0.1"
       }
     },
+    "react-measure": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/react-measure/-/react-measure-2.3.0.tgz",
+      "integrity": "sha512-dwAvmiOeblj5Dvpnk8Jm7Q8B4THF/f1l1HtKVi0XDecsG6LXwGvzV5R1H32kq3TW6RW64OAf5aoQxpIgLa4z8A==",
+      "requires": {
+        "@babel/runtime": "^7.2.0",
+        "get-node-dimensions": "^1.2.1",
+        "prop-types": "^15.6.2",
+        "resize-observer-polyfill": "^1.5.0"
+      }
+    },
     "react-overlays": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-3.1.3.tgz",
@@ -16243,6 +16259,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+    },
+    "resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
     },
     "resolve": {
       "version": "1.10.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react-leaflet": "^2.1.4",
     "react-loader": "^2.4.5",
     "react-markdown": "^4.0.6",
+    "react-measure": "^2.3.0",
     "react-scripts": "^2.1.8",
     "react-select": "^2.3.0",
     "url-join": "^4.0.0",

--- a/src/components/app-root/App/App.js
+++ b/src/components/app-root/App/App.js
@@ -308,12 +308,9 @@ export default class App extends Component {
                       className='pt-2'
                       mountOnEnter
                     >
-                      {
-                        this.state.tabKey === key &&
-                        <ErrorBoundary>
-                          <TabBody {...tabs[key].props} />
-                        </ErrorBoundary>
-                      }
+                      <ErrorBoundary>
+                        <TabBody {...tabs[key].props} />
+                      </ErrorBoundary>
                     </Tab>
                   );
                 })(this.getConfig('tabs.ordering'))


### PR DESCRIPTION
This PR removes the render on tab select logic, and handles the map rendering issue documented in #137 by a different method, based on detecting size changes to the maps tab body (which gets zero dimension when deselected). This improves both the efficiency of the app overall and the behaviour of the maps tab, which now can preserve its state between tab changes.