### PR TITLE
Fix map region

### DIFF
--- a/src/components/app-root/MapsTabBody/MapsTabBody.js
+++ b/src/components/app-root/MapsTabBody/MapsTabBody.js
@@ -100,7 +100,7 @@ import T from '../../../temporary/external-text';
 import DataMap from '../../maps/DataMap';
 import BCBaseMap from '../../maps/BCBaseMap';
 import NcwmsColourbar from '../../maps/NcwmsColourbar';
-import { getWmsLogscale, regionBounds } from '../../maps/map-utils';
+import { getWmsLogscale, regionBounds, boundsToViewport } from '../../maps/map-utils';
 import styles from '../../maps/NcwmsColourbar/NcwmsColourbar.module.css';
 import { getVariableInfo, } from '../../../utils/variables-and-units';
 import Button from 'react-bootstrap/Button';
@@ -108,13 +108,6 @@ import StaticControl from '../../maps/StaticControl';
 import { allDefined } from '../../../utils/lodash-fp-extras';
 import { collectionToCanonicalUnitsSpecs } from '../../../utils/units';
 import { seasonIndexToPeriod } from '../../../utils/percentile-anomaly';
-
-
-// TODO: Move to map-utils
-const boundsToViewport = (map, bounds) => ({
-  center: bounds.getCenter(),
-  zoom: map.getBoundsZoom(bounds),
-});
 
 
 export default class MapsTabBody extends React.PureComponent {

--- a/src/components/app-root/MapsTabBody/MapsTabBody.js
+++ b/src/components/app-root/MapsTabBody/MapsTabBody.js
@@ -7,16 +7,20 @@
 //  - Managing the bounds vs the viewport (see notes below)
 //
 // This component renders two `DataMap`s, one with a baseline climate layer
-// and one with a user-selected climate layer. Map viewports are coordinated.
-// That is, when one map's viewport is changed (panned, zoomed), the other
-// map's viewport is set to the same value.
+// and one with a user-selected climate layer.
+//
+// Map viewports are coordinated. That is, when one map's viewport is changed
+// (panned, zoomed), the other map's viewport is set to the same value.
+//
+// When a new region is selected, the map viewport is set to the bounds of the
+// new region. Thereafter the user can pan and zoom as usual.
 //
 // Note on viewport coordination.
 //
-// We pass in a simple handler as `onViewportChanged` to each `DataMap`.
-// This callback is called when a change of viewport (pan, zoom) is
-// complete, and does not fire continuously during such changes, as
-// `onViewportChange` (no "d") does.
+// We pass in a handler as prop `onViewportChanged` to each `DataMap`.
+// It is is called when a change of viewport (pan, zoom) is complete, and does
+// not fire continuously during such changes, as `onViewportChange` (no "d")
+// does.
 //
 // User experience would be smoother if we used the callback `onViewportChange`,
 // but viewport change events are generated at a very high rate during panning,

--- a/src/components/app-root/MapsTabBody/MapsTabBody.js
+++ b/src/components/app-root/MapsTabBody/MapsTabBody.js
@@ -140,22 +140,23 @@ export default class MapsTabBody extends React.PureComponent {
       mapRef.current.leafletElement._onResize();
     }
   };
-  handleResize = () => {
-    // alert('resize')
-    console.log('### Maps: resize, viewport = ', this.state.viewport)
-    this.redrawMap(this.state.baselineMapRef);
-    this.redrawMap(this.state.projectedMapRef);
+  handleResize = contentRect => {
+    console.log('### Maps.handleResize, contentRect = ', contentRect)
+    // Only redraw if content has non-zero size.
+    if (contentRect.bounds.width !== 0) {
+      console.log('### Maps.handleResize: redrawing')
+      this.redrawMap(this.state.baselineMapRef);
+      this.redrawMap(this.state.projectedMapRef);
+    }
   };
 
   zoomToRegion = () => {
-    const newState = {
+    this.setState({
       viewport: boundsToViewport(
         this.state.baselineMapRef.current.leafletElement,
         regionBounds(this.props.regionOpt.value),
       ),
-    };
-    console.log('### Maps: zoomToRegion', newState)
-    this.setState(newState);
+    });
   };
 
   render() {
@@ -215,9 +216,7 @@ export default class MapsTabBody extends React.PureComponent {
     );
 
     return (
-      <Measure
-        onResize={this.handleResize}
-      >
+      <Measure bounds onResize={this.handleResize}>
         {({ measureRef }) => (
           <div ref={measureRef}>
             <Row>

--- a/src/components/maps/map-utils.js
+++ b/src/components/maps/map-utils.js
@@ -27,6 +27,8 @@ export const geometryPositionDepth = geometryType => {
 export const reverse = a => [a[1], a[0]];
 
 
+// Leaflet-specific helpers
+
 // Return a Leaflet LatLngBounds object bounding the GeoJSON geometry object.
 export const geometryBounds = geometry => {
   const depth = geometryPositionDepth(geometry.type);
@@ -38,6 +40,13 @@ export const geometryBounds = geometry => {
 
 // Return a Leaflet LatLngBounds object bounding the GeoJSON region object.
 export const regionBounds = region => geometryBounds(region.geometry);
+
+// Return a viewport object for a given map corresponding to the given bounds.
+export const boundsToViewport = (map, bounds) => ({
+  center: bounds.getCenter(),
+  zoom: map.getBoundsZoom(bounds),
+});
+
 
 
 // Generic map helpers


### PR DESCRIPTION
This PR fixes a bug in which the initial map region did not establish the viewport for the maps. This turns out to be due to some fairly obscure behavior in both React and React Leaflet, which this PR resolves fully.