### PR TITLE
Update to accept new percentilanomaly response format

### DIFF
--- a/src/components/data-displays/Summary/Summary.js
+++ b/src/components/data-displays/Summary/Summary.js
@@ -212,7 +212,7 @@ class Summary extends React.Component {
               const convertData =
                 convertUnits(displayData.units, variableInfo.unitsSpec.id);
               const displayPercentileValues =
-                map(convertData)(displayData.percentiles);
+                map(convertData)(displayData.values);
 
               // Const `data` is provided as context data to the external text.
               // The external text implements the formatting of this data for

--- a/src/components/graphs/ChangeOverTimeGraph/ChangeOverTimeGraph.js
+++ b/src/components/graphs/ChangeOverTimeGraph/ChangeOverTimeGraph.js
@@ -161,7 +161,7 @@ class ChangeOverTimeGraphDisplay extends React.Component {
     const dataUnits = statistics[0].value.units;
     const convertData = convertUnits(dataUnits, displayUnits);
     const percentileValuesByTimePeriod = flow(
-      map(stat => stat.value.percentiles),
+      map(stat => stat.value.values),
       map(map(convertData)),
     )(statistics);
 


### PR DESCRIPTION
Resolves #203 

Incorporates a small refactoring to use the term "value" instead of "percentile", the latter of which means (in math/stats lingo) the actual percentile level (e.g., the 90 in "90th percentile") and not the data value for that level.