### PR TITLE
use node v14.21.3

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@master
-    - name: Set up Node.js 9.2
+    - name: Set up Node.js 14.21.3
       uses: actions/setup-node@v1
       with:
-        node-version: 9.2
+        node-version: 14.21.3
     - name: Node.js Test Suite
       run: |
         npm install


### PR DESCRIPTION
Updated node version so the [node-ci run](https://github.com/pacificclimate/plan2adapt-v2/actions/runs/7923350791/job/21632894774) will pass with updated dependencies from [i36-address-security-alerts](https://github.com/pacificclimate/plan2adapt-v2/tree/i36-address-security-alerts) 
closes #256 
