### PR TITLE
Part 2: Update regions endpoint and region name handling

### DIFF
--- a/src/data-services/regions.js
+++ b/src/data-services/regions.js
@@ -10,11 +10,11 @@ export function fetchRegions() {
         version: '1.0.0',
         service: 'WFS',
         request: 'GetFeature',
-        typeName: 'bc_regions:bc-regions-polygon',
+        typeName: 'bc_regions:BC-regions-FNLF-84',
         maxFeatures: 100,
         outputFormat: 'application/json',
       }
     }
   )
-  .then(response => response.data)
+    .then(response => response.data)
 }

--- a/src/utils/regions.js
+++ b/src/utils/regions.js
@@ -1,10 +1,23 @@
-export const regionId = region => {
+export const regionId = (region) => {
+
+
   // Map frontend region specifier to region id used by the backend.
   const name = region.properties.english_na;
+  const group = region.properties.group
   switch (name) {
     case 'British Columbia': return 'bc';
     case 'Mount Waddington': return 'mt_waddington';
-    default: return name.toLowerCase().replace(/\W+/g, '_');
+    case 'Oweek’ala': return 'oweekala';
+    case 'Lake Babine Nadot’en': return 'lake_babine_nadoten';
+    case 'Babine-Witsuwit\'en': return 'babine-witsuwiten';
+    case 'Cariboo': if (group === 'Forestry Regions') {
+      return `${name.toLowerCase().replace(/\W+/g, '_')}_FR`;
+    }
+    case 'Kootenay / Boundary': if (group === 'Forestry Regions') {
+      return 'kootenay_boundary_FR';
+    }
+    default:
+      return name.toLowerCase().replace(/\W+/g, '_');
   }
 };
 


### PR DESCRIPTION
This PR introduces changes related to the new First Nations language families and territories that are being added to the existing set of selectable regions
A part of the larger fnlf-cmip6-release.

Changes the layer requested from GeoServer and includes some name processing to map the regions in the selector to region_Ids used by the backend.
Demo link: https://services.pacificclimate.org/dev/plan2adapt/app/