### PR TITLE
Part 4: Update Stats and Graphs pages

### DIFF
--- a/src/components/app-root/SummaryTabBody.js
+++ b/src/components/app-root/SummaryTabBody.js
@@ -33,7 +33,7 @@ export default class SummaryTabBody extends React.PureComponent {
       this.props
     )) {
       console.log('### SummaryTabBody: unsettled props', this.props)
-      return <Loader/>
+      return <Loader />
     }
 
     const region = this.props.regionOpt.value;
@@ -51,15 +51,16 @@ export default class SummaryTabBody extends React.PureComponent {
           futureTimePeriod,
           futureDecade: middleDecade(futureTimePeriod),
           baselineDecade: middleDecade(baselineTimePeriod),
-        }}/>
+        }} />
         <Summary
           region={region}
           futureTimePeriod={futureTimePeriod}
+          baselineTimePeriod={baselineTimePeriod}
           tableContents={this.getConfig('tabs.summary.table.contents')}
           variableConfig={this.getConfig('variables')}
           unitsSpecs={unitsSpecs}
         />
-        <T path='tabs.summary.notes'/>
+        <T path='tabs.summary.notes' />
       </React.Fragment>
     );
   }

--- a/src/components/data-displays/Summary/Summary.js
+++ b/src/components/data-displays/Summary/Summary.js
@@ -1,5 +1,3 @@
-// TODO: This module is waaaaayyyy too long. Break it up.
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import Table from 'react-bootstrap/Table';
@@ -16,9 +14,10 @@ import {
   getConvertUnits,
   getVariableInfo,
   unitsSuffix,
+  baselineFormat
 } from '../../../utils/variables-and-units';
 import withAsyncData from '../../../HOCs/withAsyncData';
-import { fetchSummaryStatistics } from '../../../data-services/summary-stats';
+import { fetchSummaryStatistics, fetchCsvStats } from '../../../data-services/summary-stats';
 import { allDefined } from '../../../utils/lodash-fp-extras';
 import Loader from 'react-loader';
 import styles from './Summary.module.css';
@@ -35,7 +34,10 @@ const SeasonTds = ({ data }) => {
       <T path='tabs.summary.table.rows.season' data={data} as='string' />
     </td>,
     <td>
-      <T path='tabs.summary.table.rows.ensembleMedian' data={data} as='string' />
+      <T path='tabs.summary.table.rows.baselineMedianVal' data={data} as='string' />
+    </td>,
+    <td>
+      <T path='tabs.summary.table.rows.ensembleMedianPerc' data={data} as='string' />
     </td>,
     <td>
       <T path='tabs.summary.table.rows.range' data={data} as='string' />
@@ -62,7 +64,7 @@ class Summary extends React.Component {
   static propTypes = {
     region: PropTypes.object.isRequired,
     futureTimePeriod: PropTypes.object.isRequired,
-    baselineTimePeriod: PropTypes.object,
+    baselineTimePeriod: PropTypes.object.isRequired,
 
     tableContents: PropTypes.array.isRequired,
     // Abstract specification of the summary table. Data is implicit in the
@@ -130,8 +132,8 @@ class Summary extends React.Component {
 
   static defaultProps = {
     baselineTimePeriod: {
-      start_date: 1961,
-      end_date: 1990,
+      start_date: 1981,
+      end_date: 2010,
     },
   };
 
@@ -164,6 +166,9 @@ class Summary extends React.Component {
             <th rowSpan={2} className='align-middle text-center'>
               <T path='tabs.summary.table.heading.season' />
             </th>
+            <th rowSpan={2} className='align-middle text-center'>
+              <T path='tabs.summary.table.heading.baselineMedianVal' />
+            </th>
             <th colSpan={2} className='text-center'>
               <T path='tabs.summary.table.heading.projectedChange'
                 data={this.props.baselineTimePeriod} />
@@ -171,7 +176,7 @@ class Summary extends React.Component {
           </tr>
           <tr>
             <th>
-              <T path='tabs.summary.table.heading.ensembleMedian' />
+              <T path='tabs.summary.table.heading.ensembleMedianPerc' />
             </th>
             <th>
               <T path='tabs.summary.table.heading.range' data={{ percentiles }} />
@@ -201,10 +206,9 @@ class Summary extends React.Component {
                 const variableInfo = getVariableInfo(
                   unitsSpecs, variableConfig, variable, display
                 );
-
                 // Extract data for this row
                 const displayData = getDisplayData(
-                  rowSummaryStatistics, seasonSpec.season, display
+                  rowSummaryStatistics.summaryStats, seasonSpec.season, display
                 );
 
                 // Convert data to display units
@@ -214,6 +218,10 @@ class Summary extends React.Component {
                   convertUnits(displayData.units, variableInfo.unitsSpec.id);
                 const displayPercentileValues =
                   map(convertData)(displayData.values);
+
+                // Retrieve the season median from the seasonMediansMap
+                const medians = rowSummaryStatistics.summaryStats.seasonMedians;
+                const displayBaselineMedians = baselineFormat(precision, Number.parseFloat([medians[seasonSpec.season]]));
 
                 // Const `data` is provided as context data to the external text.
                 // The external text implements the formatting of this data for
@@ -227,14 +235,17 @@ class Summary extends React.Component {
                     ...seasonSpec,
                     label: capitalize(seasonSpec.season),
                     percentileValues: displayPercentileValues,
+                    baselineMedianVal: displayBaselineMedians,
                   },
                   format: displayFormat(precision),
                   isLong,
                   unitsSuffix,
                 };
 
+
                 isStripe = row.variable !== lastVariable ? !isStripe : isStripe;
                 lastVariable = row.variable;
+                data.baselineMedianVal = Number.parseFloat([data.baselineMedianVal])
 
                 return (
                   <tr className={isStripe ? 'striped-row' : ''} >
@@ -263,25 +274,39 @@ class Summary extends React.Component {
   }
 }
 
-
-const loadSummaryStatistics = ({ region, futureTimePeriod, tableContents }) =>
+const loadSummaryStatistics = async ({ region, futureTimePeriod, tableContents }) => {
   // Return (a promise for) the summary statistics to be displayed in the
   // Summary tab. This amounts to fetching the data for each variable from the
   // backend, then processing it into the form consumed by Summary via its
   // prop `summary`.
-  Promise.all(
-    map(
-      content => fetchSummaryStatistics(
-        region, futureTimePeriod, content.variable, percentiles
+  const dataFetches = tableContents.map(content =>
+    Promise.all([
+      fetchSummaryStatistics(region, futureTimePeriod, content.variable, percentiles),
+      ...content.seasons.map(season =>
+        fetchCsvStats(region, content.variable, season)
+          .then(median => ({ season, median }))
+          .catch(err => {
+            console.error(`Failed to fetch median for ${content.variable} in ${season}:`, err);
+            return { season, median: null };  // Return null median on error
+          })
       )
-        // Unavailable or otherwise problematic fetches are returned as undefined.
-        // Data display elements are responsible for showing a message.
-        .catch(err => {
-          console.error('Failed to fetch summary statistics:\n', err);
-          return undefined;
-        })
-    )(tableContents)
+    ])
+      .then(([summaryStats, ...seasonMedians]) => {
+        // Map from season names to median values
+        const seasonMediansMap = seasonMedians.reduce((acc, { season, median }) => {
+          acc[season] = median;
+          return acc;
+        }, {});
+        summaryStats.seasonMedians = seasonMediansMap;
+        return {
+          variable: content.variable,
+          summaryStats,
+        };
+      })
   );
+
+  return Promise.all(dataFetches);
+};
 
 
 export const shouldLoadSummaryStatistics = (prevProps, props) =>
@@ -291,6 +316,8 @@ export const shouldLoadSummaryStatistics = (prevProps, props) =>
       'region.geometry',
       'futureTimePeriod.start_date',
       'futureTimePeriod.end_date',
+      'baselineTimePeriod.start_date',
+      'baselineTimePeriod.end_date',
       'tableContents',
     ],
     props

--- a/src/utils/percentile-anomaly.js
+++ b/src/utils/percentile-anomaly.js
@@ -112,6 +112,9 @@ export const getDisplayData = (response, period, display) => {
   }
 
   const anomalyValues = getPeriodData(response.anomaly, period);
+  const baselineValue = getPeriodData(response.baseline, period);
+
+
   if (display === 'absolute') {
     return {
       values: anomalyValues,
@@ -120,7 +123,7 @@ export const getDisplayData = (response, period, display) => {
   }
 
   // display === 'relative':
-  const baselineValue = getPeriodData(response.baseline, period);
+
   // TODO: Get zero tolerance from config
   if (nearZero(baselineValue)) {
     return {
@@ -129,7 +132,7 @@ export const getDisplayData = (response, period, display) => {
     }
   }
   return {
-    values: map(x => 100 * x/baselineValue)(anomalyValues),
+    values: map(x => 100 * x / baselineValue)(anomalyValues),
     units: '%',
   };
 };

--- a/src/utils/variables-and-units.js
+++ b/src/utils/variables-and-units.js
@@ -23,7 +23,7 @@ const getConfigForId = (variableConfig, variableId) => {
 
 export const getVariableLabel = (variableConfig, variableId) => {
   const vc = getConfigForId(variableConfig, variableId);
-  return `${vc.label}${vc.derived ? '*' : ''}`;
+  return `${vc.label}`;
 };
 
 
@@ -77,7 +77,7 @@ export const getVariableInfo = (unitsSpecs, variableConfig, variableId, display)
 };
 
 
-export const getConvertUnits= (unitsSpecs, variableConfig, variableId) => {
+export const getConvertUnits = (unitsSpecs, variableConfig, variableId) => {
   const variableType = getVariableType(variableConfig, variableId);
   if (!variableType) {
     throw new Error(`Unspecified variable type for ${variableId}`);
@@ -113,10 +113,18 @@ export const expToFixed = s => {
 };
 
 
-export const displayFormat = curry((sigfigs , value) => {
+export const displayFormat = curry((sigfigs, value) => {
   // Convert a number value to a string in the display format we prefer.
   if (!isNumber(value)) {
     return '--';
   }
   return `${value > 0 ? '+' : ''}${expToFixed(value.toPrecision(sigfigs))}`;
 });
+
+
+export const baselineFormat = (sigfigs, value) => {
+  if (!isNumber(value)) {
+    return '--';
+  }
+  return expToFixed(value.toPrecision(sigfigs));
+};


### PR DESCRIPTION
This PR focuses on updates to graphs and statistical pages within the application. These changes are part of the larger fnlf-cmip6-release.

Key changes include:
- New baseline median column on the stats page. Cell values include variable-specific formatting for units and precision.
- Graph tab hover popups display projected values, with units and precision.
- Graph tab baseline point displays the baseline median value
- Includes a new function to fetch median statistics from precalculated regional stat files.

Demo link: http://beehive.pacificclimate.org/plan2adapt/app