### PR TITLE
Part 4: Update Graphs and Stats pages

### DIFF
--- a/public/external-text/default.yaml
+++ b/public/external-text/default.yaml
@@ -76,13 +76,13 @@ tabs:
         - variable: tasmean
           display: absolute
           displayUnits: °C
-          precision: 2
+          precision: 1
           seasons:
             - annual
         - variable: pr
           display: relative
           displayUnits: '%'
-          precision: 2
+          precision: 1
           seasons:
             - annual
             - summer
@@ -90,7 +90,7 @@ tabs:
         - variable: prsn
           display: relative
           displayUnits: '%'
-          precision: 2
+          precision: 1
           seasons:
             - annual
             - winter
@@ -98,25 +98,25 @@ tabs:
         - variable: gdd
           display: absolute
           displayUnits: degree-days
-          precision: 3
+          precision: 0
           seasons:
             - annual
         - variable: ffd
           display: absolute
           displayUnits: days
-          precision: 2
+          precision: 0
           seasons:
             - annual
         - variable: hdd
           display: absolute
           displayUnits: degree-days
-          precision: 3
+          precision: 0
           seasons:
             - annual
         - variable: cdd
           display: absolute
           displayUnits: degree-days
-          precision: 3
+          precision: 0
           seasons:
             - annual
     notes: |
@@ -558,24 +558,38 @@ tabs:
         ffd:
           display: absolute
           displayUnits: days
+          precision: 0
+          medianUnit: days
         gdd:
           display: absolute
           displayUnits: degree-days
+          precision: 0
+          medianUnit: degree-days
         hdd:
           display: absolute
           displayUnits: degree-days
+          precision: 0
+          medianUnit: degree-days
         cdd:
           display: absolute
           displayUnits: degree-days
+          precision: 0
+          medianUnit: degree-days
         pr:
           display: relative
           displayUnits: '%'
-        prsn:
+          precision: 1
+          medianUnit: mm/day
+        snow:
           display: relative
           displayUnits: '%'
-        tasmean:
+          precision: 1
+          medianUnit: mm/day
+        tas:
           display: absolute
           displayUnits: °C
+          precision: 1
+          medianUnit: °C
 
   notes:
     disabled: false

--- a/src/components/app-root/SummaryTabBody.js
+++ b/src/components/app-root/SummaryTabBody.js
@@ -33,7 +33,7 @@ export default class SummaryTabBody extends React.PureComponent {
       this.props
     )) {
       console.log('### SummaryTabBody: unsettled props', this.props)
-      return <Loader/>
+      return <Loader />
     }
 
     const region = this.props.regionOpt.value;
@@ -51,15 +51,16 @@ export default class SummaryTabBody extends React.PureComponent {
           futureTimePeriod,
           futureDecade: middleDecade(futureTimePeriod),
           baselineDecade: middleDecade(baselineTimePeriod),
-        }}/>
+        }} />
         <Summary
           region={region}
           futureTimePeriod={futureTimePeriod}
+          baselineTimePeriod={baselineTimePeriod}
           tableContents={this.getConfig('tabs.summary.table.contents')}
           variableConfig={this.getConfig('variables')}
           unitsSpecs={unitsSpecs}
         />
-        <T path='tabs.summary.notes'/>
+        <T path='tabs.summary.notes' />
       </React.Fragment>
     );
   }

--- a/src/components/data-displays/Summary/Summary.js
+++ b/src/components/data-displays/Summary/Summary.js
@@ -34,7 +34,7 @@ const SeasonTds = ({ data }) => {
       <T path='tabs.summary.table.rows.season' data={data} as='string' />
     </td>,
     <td>
-      <T path='tabs.summary.table.rows.baselineMedianVal' data={data} as='string' />
+      <T path='tabs.summary.table.rows.baselineMeanVal' data={data} as='string' />
     </td>,
     <td>
       <T path='tabs.summary.table.rows.ensembleMedianPerc' data={data} as='string' />
@@ -167,7 +167,7 @@ class Summary extends React.Component {
               <T path='tabs.summary.table.heading.season' />
             </th>
             <th rowSpan={2} className='align-middle text-center'>
-              <T path='tabs.summary.table.heading.baselineMedianVal' />
+              <T path='tabs.summary.table.heading.baselineMeanVal' />
             </th>
             <th colSpan={2} className='text-center'>
               <T path='tabs.summary.table.heading.projectedChange'
@@ -220,8 +220,8 @@ class Summary extends React.Component {
                   map(convertData)(displayData.values);
 
                 // Retrieve the season median from the seasonMediansMap
-                const medians = rowSummaryStatistics.summaryStats.seasonMedians;
-                const displayBaselineMedians = baselineFormat(precision, Number.parseFloat([medians[seasonSpec.season]]));
+                const means = rowSummaryStatistics.summaryStats.seasonMeans;
+                const displayBaselineMeans = baselineFormat(precision, Number.parseFloat([means[seasonSpec.season]]));
 
                 // Const `data` is provided as context data to the external text.
                 // The external text implements the formatting of this data for
@@ -235,7 +235,7 @@ class Summary extends React.Component {
                     ...seasonSpec,
                     label: capitalize(seasonSpec.season),
                     percentileValues: displayPercentileValues,
-                    baselineMedianVal: displayBaselineMedians,
+                    baselineMeanVal: displayBaselineMeans,
                   },
                   format: displayFormat(precision),
                   isLong,
@@ -245,7 +245,7 @@ class Summary extends React.Component {
 
                 isStripe = row.variable !== lastVariable ? !isStripe : isStripe;
                 lastVariable = row.variable;
-                data.baselineMedianVal = Number.parseFloat([data.baselineMedianVal])
+                data.baselineMeanVal = Number.parseFloat([data.baselineMeanVal])
 
                 return (
                   <tr className={isStripe ? 'striped-row' : ''} >
@@ -284,20 +284,20 @@ const loadSummaryStatistics = async ({ region, futureTimePeriod, tableContents }
       fetchSummaryStatistics(region, futureTimePeriod, content.variable, percentiles),
       ...content.seasons.map(season =>
         fetchCsvStats(region, content.variable, season)
-          .then(median => ({ season, median }))
+          .then(mean => ({ season, mean }))
           .catch(err => {
-            console.error(`Failed to fetch median for ${content.variable} in ${season}:`, err);
-            return { season, median: null };  // Return null median on error
+            console.error(`Failed to fetch mean for ${content.variable} in ${season}:`, err);
+            return { season, mean: null };  // Return null mean on error
           })
       )
     ])
-      .then(([summaryStats, ...seasonMedians]) => {
-        // Map from season names to median values
-        const seasonMediansMap = seasonMedians.reduce((acc, { season, median }) => {
-          acc[season] = median;
+      .then(([summaryStats, ...seasonMeans]) => {
+        // Map from season names to mean values
+        const seasonMeansMap = seasonMeans.reduce((acc, { season, mean }) => {
+          acc[season] = mean;
           return acc;
         }, {});
-        summaryStats.seasonMedians = seasonMediansMap;
+        summaryStats.seasonMeans = seasonMeansMap;
         return {
           variable: content.variable,
           summaryStats,

--- a/src/components/data-displays/Summary/Summary.js
+++ b/src/components/data-displays/Summary/Summary.js
@@ -1,5 +1,3 @@
-// TODO: This module is waaaaayyyy too long. Break it up.
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import Table from 'react-bootstrap/Table';
@@ -16,9 +14,10 @@ import {
   getConvertUnits,
   getVariableInfo,
   unitsSuffix,
+  baselineFormat
 } from '../../../utils/variables-and-units';
 import withAsyncData from '../../../HOCs/withAsyncData';
-import { fetchSummaryStatistics } from '../../../data-services/summary-stats';
+import { fetchSummaryStatistics, fetchCsvStats } from '../../../data-services/summary-stats';
 import { allDefined } from '../../../utils/lodash-fp-extras';
 import Loader from 'react-loader';
 import styles from './Summary.module.css';
@@ -35,7 +34,10 @@ const SeasonTds = ({ data }) => {
       <T path='tabs.summary.table.rows.season' data={data} as='string' />
     </td>,
     <td>
-      <T path='tabs.summary.table.rows.ensembleMedian' data={data} as='string' />
+      <T path='tabs.summary.table.rows.baselineMedianVal' data={data} as='string' />
+    </td>,
+    <td>
+      <T path='tabs.summary.table.rows.ensembleMedianPerc' data={data} as='string' />
     </td>,
     <td>
       <T path='tabs.summary.table.rows.range' data={data} as='string' />
@@ -62,7 +64,7 @@ class Summary extends React.Component {
   static propTypes = {
     region: PropTypes.object.isRequired,
     futureTimePeriod: PropTypes.object.isRequired,
-    baselineTimePeriod: PropTypes.object,
+    baselineTimePeriod: PropTypes.object.isRequired,
 
     tableContents: PropTypes.array.isRequired,
     // Abstract specification of the summary table. Data is implicit in the
@@ -130,8 +132,8 @@ class Summary extends React.Component {
 
   static defaultProps = {
     baselineTimePeriod: {
-      start_date: 1961,
-      end_date: 1990,
+      start_date: 1981,
+      end_date: 2010,
     },
   };
 
@@ -164,6 +166,9 @@ class Summary extends React.Component {
             <th rowSpan={2} className='align-middle text-center'>
               <T path='tabs.summary.table.heading.season' />
             </th>
+            <th rowSpan={2} className='align-middle text-center'>
+              <T path='tabs.summary.table.heading.baselineMedianVal' />
+            </th>
             <th colSpan={2} className='text-center'>
               <T path='tabs.summary.table.heading.projectedChange'
                 data={this.props.baselineTimePeriod} />
@@ -171,7 +176,7 @@ class Summary extends React.Component {
           </tr>
           <tr>
             <th>
-              <T path='tabs.summary.table.heading.ensembleMedian' />
+              <T path='tabs.summary.table.heading.ensembleMedianPerc' />
             </th>
             <th>
               <T path='tabs.summary.table.heading.range' data={{ percentiles }} />
@@ -201,10 +206,9 @@ class Summary extends React.Component {
                 const variableInfo = getVariableInfo(
                   unitsSpecs, variableConfig, variable, display
                 );
-
                 // Extract data for this row
                 const displayData = getDisplayData(
-                  rowSummaryStatistics, seasonSpec.season, display
+                  rowSummaryStatistics.summaryStats, seasonSpec.season, display
                 );
 
                 // Convert data to display units
@@ -214,6 +218,10 @@ class Summary extends React.Component {
                   convertUnits(displayData.units, variableInfo.unitsSpec.id);
                 const displayPercentileValues =
                   map(convertData)(displayData.values);
+
+                // Retrieve the season median from the seasonMediansMap
+                const medians = rowSummaryStatistics.summaryStats.seasonMedians;
+                const displayBaselineMedians = baselineFormat(precision, Number.parseFloat([medians[seasonSpec.season]]));
 
                 // Const `data` is provided as context data to the external text.
                 // The external text implements the formatting of this data for
@@ -227,14 +235,17 @@ class Summary extends React.Component {
                     ...seasonSpec,
                     label: capitalize(seasonSpec.season),
                     percentileValues: displayPercentileValues,
+                    baselineMedianVal: displayBaselineMedians,
                   },
                   format: displayFormat(precision),
                   isLong,
                   unitsSuffix,
                 };
 
+
                 isStripe = row.variable !== lastVariable ? !isStripe : isStripe;
                 lastVariable = row.variable;
+                data.baselineMedianVal = Number.parseFloat([data.baselineMedianVal])
 
                 return (
                   <tr className={isStripe ? 'striped-row' : ''} >
@@ -263,25 +274,39 @@ class Summary extends React.Component {
   }
 }
 
-
-const loadSummaryStatistics = ({ region, futureTimePeriod, tableContents }) =>
+const loadSummaryStatistics = async ({ region, futureTimePeriod, tableContents }) => {
   // Return (a promise for) the summary statistics to be displayed in the
   // Summary tab. This amounts to fetching the data for each variable from the
   // backend, then processing it into the form consumed by Summary via its
   // prop `summary`.
-  Promise.all(
-    map(
-      content => fetchSummaryStatistics(
-        region, futureTimePeriod, content.variable, percentiles
+  const dataFetches = tableContents.map(content =>
+    Promise.all([
+      fetchSummaryStatistics(region, futureTimePeriod, content.variable, percentiles),
+      ...content.seasons.map(season =>
+        fetchCsvStats(region, content.variable, season)
+          .then(median => ({ season, median }))
+          .catch(err => {
+            console.error(`Failed to fetch median for ${content.variable} in ${season}:`, err);
+            return { season, median: null };  // Return null median on error
+          })
       )
-        // Unavailable or otherwise problematic fetches are returned as undefined.
-        // Data display elements are responsible for showing a message.
-        .catch(err => {
-          console.error('Failed to fetch summary statistics:\n', err);
-          return undefined;
-        })
-    )(tableContents)
+    ])
+      .then(([summaryStats, ...seasonMedians]) => {
+        // Map from season names to median values
+        const seasonMediansMap = seasonMedians.reduce((acc, { season, median }) => {
+          acc[season] = median;
+          return acc;
+        }, {});
+        summaryStats.seasonMedians = seasonMediansMap;
+        return {
+          variable: content.variable,
+          summaryStats,
+        };
+      })
   );
+
+  return Promise.all(dataFetches);
+};
 
 
 export const shouldLoadSummaryStatistics = (prevProps, props) =>
@@ -291,6 +316,8 @@ export const shouldLoadSummaryStatistics = (prevProps, props) =>
       'region.geometry',
       'futureTimePeriod.start_date',
       'futureTimePeriod.end_date',
+      'baselineTimePeriod.start_date',
+      'baselineTimePeriod.end_date',
       'tableContents',
     ],
     props

--- a/src/components/graphs/BarChart.js
+++ b/src/components/graphs/BarChart.js
@@ -52,7 +52,7 @@ export default class BarChart extends React.Component {
 
     percentiles: PropTypes.array,
     percentileValuesByTimePeriod: PropTypes.array,
-    median: PropTypes.object,
+    mean: PropTypes.object,
     variableConfig: PropTypes.object
   };
 
@@ -61,7 +61,7 @@ export default class BarChart extends React.Component {
       baselineTimePeriod, futureTimePeriods,
       graphConfig, variableInfo,
       percentiles, percentileValuesByTimePeriod,
-      median, variableConfig,
+      mean, variableConfig,
     } = this.props;
 
     const percentileIndices = range(0, percentiles.length);
@@ -349,8 +349,8 @@ export default class BarChart extends React.Component {
                 index === 0
                 && id === basePercentileValueNames[0]
               ) {
-                const medianUnit = variableConfig[variableInfo.id].medianUnit
-                return `Median Value\n ${baselineFormat(precision, Number.parseFloat(median))} ${medianUnit}`;
+                const meanUnit = variableConfig[variableInfo.id].meanUnit
+                return `Mean Value\n ${baselineFormat(precision, Number.parseFloat(mean))} ${meanUnit}`;
               }
               const year = baseTimes[index];
               if (

--- a/src/components/graphs/BarChart.js
+++ b/src/components/graphs/BarChart.js
@@ -79,8 +79,11 @@ export default class BarChart extends React.Component {
     // no negative values. It is the (negative of) the most negative value
     // otherwise, rounded to a multiple of 2 so that C3's automatic y-axis
     // tick values are nice.
+    const precision = variableConfig[variableInfo.id].precision;
+    const formatValues = values => values.map(v => parseFloat(displayFormat(precision, v)));
+    const formattedPercentileValuesByTimePeriod = percentileValuesByTimePeriod.map(formatValues);
+    const allPercentileValues = flattenDeep([0, formattedPercentileValuesByTimePeriod]);
 
-    const allPercentileValues = flattenDeep([0, percentileValuesByTimePeriod]);
     const minPercentileValue = min(allPercentileValues);
     const maxPercentileValue = max(allPercentileValues);
 
@@ -341,11 +344,11 @@ export default class BarChart extends React.Component {
               return `${name} %ile`;
             },
             value: (value, ratio, id, index) => {
+              const precision = variableConfig[variableInfo.id].precision
               if (
                 index === 0
                 && id === basePercentileValueNames[0]
               ) {
-                const precision = variableConfig[variableInfo.id].precision
                 const medianUnit = variableConfig[variableInfo.id].medianUnit
                 return `Median Value\n ${baselineFormat(precision, Number.parseFloat(median))} ${medianUnit}`;
               }
@@ -354,7 +357,7 @@ export default class BarChart extends React.Component {
                 includes(id, basePercentileValueNames)
                 && includes(year, futureMiddleYears)
               ) {
-                const displayValue = displayFormat(2, value - offset);
+                const displayValue = displayFormat(precision, value - offset);
                 return `${displayValue} ${variableInfo.unitsSpec.id}`;
               }
             },

--- a/src/components/graphs/ChangeOverTimeGraph/ChangeOverTimeGraph.js
+++ b/src/components/graphs/ChangeOverTimeGraph/ChangeOverTimeGraph.js
@@ -74,7 +74,7 @@ class ChangeOverTimeGraphDisplay extends React.Component {
     //
     // There is one item per element of futureTimePeriods, in corresponding
     // order.
-    median: PropTypes.any,
+    mean: PropTypes.any,
     // This prop receives the data-fetch responses the backend according
     // props region, season, variable. (`withAsyncData`
     // injects this data.)
@@ -111,7 +111,7 @@ class ChangeOverTimeGraphDisplay extends React.Component {
         'baselineTimePeriod',
         'futureTimePeriods[0]',
         'statistics',
-        'median',
+        'mean',
         'graphConfig',
         'variableConfig',
         'unitsSpecs',
@@ -123,7 +123,7 @@ class ChangeOverTimeGraphDisplay extends React.Component {
     }
     const {
       baselineTimePeriod, futureTimePeriods,
-      statistics, median,
+      statistics, mean,
       variableInfo,
       graphConfig, variableConfig, unitsSpecs,
     } = this.props;
@@ -181,7 +181,7 @@ class ChangeOverTimeGraphDisplay extends React.Component {
           variableInfo={variableInfo}
           percentiles={percentiles}
           percentileValuesByTimePeriod={percentileValuesByTimePeriod}
-          median={median}
+          mean={mean}
           variableConfig={variableConfig}
         />
       </React.Fragment>
@@ -196,13 +196,13 @@ const convertToDisplayData = curry((graphConfig, variableId, season, data) => {
 });
 
 
-const loadMedianData = ({ region, variable, season }) => {
+const loadMeanData = ({ region, variable, season }) => {
   const variableId = variable.representative.variable_id;
   const seasonPeriod = seasonIndexToPeriod(season);
   return fetchCsvStats(region, variableId, seasonPeriod);
 };
 
-const shouldLoadMedianData = (prevProps, props) =>
+const shouldLoadMeanData = (prevProps, props) =>
   allDefined(['region', 'variable', 'season'], props) &&
   !(
     prevProps &&
@@ -274,7 +274,7 @@ const ChangeOverTimeGraph = withAsyncData(
   loadSummaryStatistics, shouldLoadSummaryStatistics, 'statistics'
 )(
   withAsyncData(
-    loadMedianData, shouldLoadMedianData, 'median'
+    loadMeanData, shouldLoadMeanData, 'mean'
   )(ChangeOverTimeGraphDisplay)
 );
 

--- a/src/components/graphs/PseudoFilledLineGraph.js
+++ b/src/components/graphs/PseudoFilledLineGraph.js
@@ -139,7 +139,8 @@ export default class PseudoFilledLineGraph extends React.Component {
             name: name => `${name} %ile`,
             value: (value, ratio, id) => {
               if (includes(id, ['10th', '25th', '50th', '75th', '90th'])) {
-                return `${displayFormat(2, value)} ${variableInfo.units}`;
+                const precision = variableConfig[variableInfo.id].precision
+                return `${displayFormat(precision, value)} ${variableInfo.units}`;
               }
             },
           },

--- a/src/components/graphs/SimpleLineGraph.js
+++ b/src/components/graphs/SimpleLineGraph.js
@@ -89,7 +89,8 @@ export default class SimpleLineGraph extends React.Component {
             name: name => `${name} %ile`,
             value: (value, ratio, id) => {
               if (includes(id, ['10th', '25th', '50th', '75th', '90th'])) {
-                return `${displayFormat(2, value)} ${variableInfo.units}`;
+                const precision = variableConfig[variableInfo.id].precision
+                return `${displayFormat(precision, value)} ${variableInfo.units}`;
               }
             },
           },

--- a/src/data-services/summary-stats.js
+++ b/src/data-services/summary-stats.js
@@ -55,17 +55,17 @@ export const fetchCsvStats = (region, variable, season) => {
       return parseCSV(response.data);
     })
     .then(data => {
-      const medianEntry = data.find(row =>
+      const meanEntry = data.find(row =>
         row.variable === variable &&
         row.model === "PCIC_BLEND_v1" &&
         row.timescale === periodToTimescale(season) &&
         parseInt(row.timeidx, 10) === seasonToIndex[season]
       );
-      if (!medianEntry) {
+      if (!meanEntry) {
         console.error(`No matching entry found for ${variable} in season ${season}`);
         return null;
       }
-      return medianEntry.median;
+      return meanEntry.mean;
     })
     .catch(error => {
       console.error(`Error fetching or parsing CSV data from ${csvUrl} for ${variable}, season ${season}:`, error);

--- a/src/data-services/summary-stats.js
+++ b/src/data-services/summary-stats.js
@@ -31,7 +31,9 @@ export const fetchSummaryStatistics = (
     .then(response => response.data);
 };
 
-
+// This mapping is used to translate season names to their respective indices in the CSV stats files.
+// "Season" in this case refers to the row-mapping of the summary table,
+// where annual entries will always have a timeidx of 0. 
 const seasonToIndex = {
   'winter': 0,
   'spring': 1,
@@ -39,6 +41,7 @@ const seasonToIndex = {
   'fall': 3,
   'annual': 0
 };
+
 
 // Fetch and parse CSV data
 export const fetchCsvStats = (region, variable, season) => {
@@ -74,8 +77,6 @@ function parseCSV(data) {
   const lines = data.split('\n');
   const result = [];
   const headers = lines[0].split(',').map(header => header.trim());
-
-  //console.log(`CSV headers: ${headers.join(', ')}`);
 
   for (let i = 1; i < lines.length; i++) {
     if (lines[i].trim() === "") {

--- a/src/utils/percentile-anomaly.js
+++ b/src/utils/percentile-anomaly.js
@@ -112,6 +112,9 @@ export const getDisplayData = (response, period, display) => {
   }
 
   const anomalyValues = getPeriodData(response.anomaly, period);
+  const baselineValue = getPeriodData(response.baseline, period);
+
+
   if (display === 'absolute') {
     return {
       values: anomalyValues,
@@ -120,7 +123,7 @@ export const getDisplayData = (response, period, display) => {
   }
 
   // display === 'relative':
-  const baselineValue = getPeriodData(response.baseline, period);
+
   // TODO: Get zero tolerance from config
   if (nearZero(baselineValue)) {
     return {
@@ -129,7 +132,7 @@ export const getDisplayData = (response, period, display) => {
     }
   }
   return {
-    values: map(x => 100 * x/baselineValue)(anomalyValues),
+    values: map(x => 100 * x / baselineValue)(anomalyValues),
     units: '%',
   };
 };

--- a/src/utils/variables-and-units.js
+++ b/src/utils/variables-and-units.js
@@ -99,32 +99,32 @@ export const unitsSuffix = units => {
   return `${units.match(/^[%]/) ? '' : ' '}${units}`;
 };
 
+// No longer used. setting precision with decimal places rather than sigfigs. 
+// export const expToFixed = s => {
+//   // Convert a string representing a number in exponential notation to a string
+//   // in (nominally) fixed point notation. Why? Because `Number.toPrecision()`
+//   // returns exponential notation frequently when we do not want it to. So
+//   // we apply this.
+//   const match = s.match(/-?\d\.\d+e[+-]\d+/);
+//   if (!match) {
+//     return s;
+//   }
+//   return Number.parseFloat(match[0]).toString();
+// };
 
-export const expToFixed = s => {
-  // Convert a string representing a number in exponential notation to a string
-  // in (nominally) fixed point notation. Why? Because `Number.toPrecision()`
-  // returns exponential notation frequently when we do not want it to. So
-  // we apply this.
-  const match = s.match(/-?\d\.\d+e[+-]\d+/);
-  if (!match) {
-    return s;
-  }
-  return Number.parseFloat(match[0]).toString();
-};
 
-
-export const displayFormat = curry((sigfigs, value) => {
+export const displayFormat = curry((decimalPlaces, value) => {
   // Convert a number value to a string in the display format we prefer.
   if (!isNumber(value)) {
     return '--';
   }
-  return `${value > 0 ? '+' : ''}${expToFixed(value.toPrecision(sigfigs))}`;
+  return `${value > 0 ? '+' : ''}${value.toFixed(decimalPlaces)}`;
 });
 
 
-export const baselineFormat = (sigfigs, value) => {
+export const baselineFormat = (decimalPlaces, value) => {
   if (!isNumber(value)) {
     return '--';
   }
-  return expToFixed(value.toPrecision(sigfigs));
+  return value.toFixed(decimalPlaces);
 };

--- a/src/utils/variables-and-units.js
+++ b/src/utils/variables-and-units.js
@@ -23,7 +23,7 @@ const getConfigForId = (variableConfig, variableId) => {
 
 export const getVariableLabel = (variableConfig, variableId) => {
   const vc = getConfigForId(variableConfig, variableId);
-  return `${vc.label}${vc.derived ? '*' : ''}`;
+  return `${vc.label}`;
 };
 
 
@@ -77,7 +77,7 @@ export const getVariableInfo = (unitsSpecs, variableConfig, variableId, display)
 };
 
 
-export const getConvertUnits= (unitsSpecs, variableConfig, variableId) => {
+export const getConvertUnits = (unitsSpecs, variableConfig, variableId) => {
   const variableType = getVariableType(variableConfig, variableId);
   if (!variableType) {
     throw new Error(`Unspecified variable type for ${variableId}`);
@@ -113,10 +113,18 @@ export const expToFixed = s => {
 };
 
 
-export const displayFormat = curry((sigfigs , value) => {
+export const displayFormat = curry((sigfigs, value) => {
   // Convert a number value to a string in the display format we prefer.
   if (!isNumber(value)) {
     return '--';
   }
   return `${value > 0 ? '+' : ''}${expToFixed(value.toPrecision(sigfigs))}`;
 });
+
+
+export const baselineFormat = (sigfigs, value) => {
+  if (!isNumber(value)) {
+    return '--';
+  }
+  return expToFixed(value.toPrecision(sigfigs));
+};


### PR DESCRIPTION
This PR focuses on updates to graphs and statistical pages within the application. These changes are part of the larger fnlf-cmip6-release.

Key changes include:
- New baseline mean column on the stats page. Cell values include variable-specific formatting for units and precision.
- Graph tab hover popups display projected values, with units and precision.
- Graph tab baseline point displays the baseline median value
- Includes a new function to fetch median statistics from precalculated regional stat files.

Demo link: https://services.pacificclimate.org/dev/plan2adapt/app/