### PR TITLE
I271 vector tile basemaps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12096,7 +12096,7 @@
       }
     },
     "pcic-react-leaflet-components": {
-      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#7a22b7d0149357ea8f25c35d155c5899d6516756",
+      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#d041cb8dd9809f3530ae34ed12b2de362a077b18",
       "from": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#add-BCVectorBaseMap",
       "requires": {
         "@testing-library/jest-dom": "^5.16.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12093,7 +12093,7 @@
       }
     },
     "pcic-react-leaflet-components": {
-      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#127dcfaffc4e2a66c115cd024d4cf4f2d8eb82aa",
+      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#e860436643123f550a1d8d4128e59d6a5a5cd31d",
       "from": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#add-BCVectorBaseMap",
       "requires": {
         "@testing-library/jest-dom": "^5.16.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12096,7 +12096,7 @@
       }
     },
     "pcic-react-leaflet-components": {
-      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#0379024e4878534ec95e7d5a971dc2d0f4621986",
+      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#701bf40345283dc2147ec1d5a3894fd8181b5016",
       "from": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#add-BCVectorBaseMap",
       "requires": {
         "@testing-library/jest-dom": "^5.16.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12096,7 +12096,7 @@
       }
     },
     "pcic-react-leaflet-components": {
-      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#4421dd2932c143df666340afb69efe6f43af6a44",
+      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#0ef9ca5e46d2eac783bdd7e841b0f3fcfd75bc3a",
       "from": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#add-BCVectorBaseMap",
       "requires": {
         "@testing-library/jest-dom": "^5.16.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3525,11 +3525,11 @@
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w=="
     },
     "@types/node": {
-      "version": "22.2.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.2.0.tgz",
-      "integrity": "sha512-bm6EG6/pCpkxDf/0gDNDdtDILMOHgaQBVOJGdwsqClnxA3xL6jtMv76rLBc006RVMWbmaf0xbmom4Z/5o2nRkQ==",
+      "version": "22.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.3.0.tgz",
+      "integrity": "sha512-nrWpWVaDZuaVc5X84xJ0vNrLvomM205oQyLsRt7OHNZbSHslcWsvgFR7O7hire2ZonjLrWBbedmotmIlJDVd6g==",
       "requires": {
-        "undici-types": "~6.13.0"
+        "undici-types": "~6.18.2"
       }
     },
     "@types/node-forge": {
@@ -6106,9 +6106,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.5.6",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.6.tgz",
-      "integrity": "sha512-jwXWsM5RPf6j9dPYzaorcBSUg6AiqocPEyMpkchkvntaH9HGfOOMZwxMJjDY/XEs3T5dM7uyH1VhRMkqUU9qVw=="
+      "version": "1.5.7",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.7.tgz",
+      "integrity": "sha512-6FTNWIWMxMy/ZY6799nBlPtF1DFDQ6VQJ7yyDP27SJNt5lwtQ5ufqVvHylb3fdQefvRcgA3fKcFMJi9OLwBRNw=="
     },
     "emittery": {
       "version": "0.8.1",
@@ -12096,7 +12096,7 @@
       }
     },
     "pcic-react-leaflet-components": {
-      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#4e7ea371d7277e3eeacd57d679b31745b4fb1c84",
+      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#bfef0790d8815978a53b26da9549e3acae229103",
       "from": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#add-BCVectorBaseMap",
       "requires": {
         "@testing-library/jest-dom": "^5.16.4",
@@ -15195,9 +15195,9 @@
       "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
     },
     "undici-types": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.13.0.tgz",
-      "integrity": "sha512-xtFJHudx8S2DSoujjMd1WeWvn7KKWFRESZTMeL1RptAYERu29D6jphMjjY+vn96jvN3kVPDNxU/E13VTaXj6jg=="
+      "version": "6.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.18.2.tgz",
+      "integrity": "sha512-5ruQbENj95yDYJNS3TvcaxPMshV7aizdv/hWYjGIKoANWKjhWNBsr2YEuYZKodQulB1b8l7ILOuDQep3afowQQ=="
     },
     "unherit": {
       "version": "1.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12096,7 +12096,7 @@
       }
     },
     "pcic-react-leaflet-components": {
-      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#ddcbefa230ca2f0cd7cf205f175dc5355088c28c",
+      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#713c9bcc5e26bfb51612c6ae82e3b3d55a2d3ee1",
       "from": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#add-BCVectorBaseMap",
       "requires": {
         "@testing-library/jest-dom": "^5.16.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4860,9 +4860,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001650",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001650.tgz",
-      "integrity": "sha512-fgEc7hP/LB7iicdXHUI9VsBsMZmUmlVJeQP2qqQW+3lkqVhbmjEU8zp+h5stWeilX+G7uXuIUIIlWlDw9jdt8g=="
+      "version": "1.0.30001651",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001651.tgz",
+      "integrity": "sha512-9Cf+Xv1jJNe1xPZLGuUXLNkE1BoDkqRqYyFJ9TDYSqhduqA4hu4oR9HluGoWYQC/aj8WHjsGVV+bwkh0+tegRg=="
     },
     "case-sensitive-paths-webpack-plugin": {
       "version": "2.4.0",
@@ -12093,7 +12093,7 @@
       }
     },
     "pcic-react-leaflet-components": {
-      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#dd25faac9765537aa959c9dc419d587cd71d3183",
+      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#224b08b272bfee192982f7e02b692e6193cd93eb",
       "from": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#add-BCVectorBaseMap",
       "requires": {
         "@testing-library/jest-dom": "^5.16.4",
@@ -14759,9 +14759,9 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
     },
     "tailwindcss": {
-      "version": "3.4.8",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.8.tgz",
-      "integrity": "sha512-GkP17r9GQkxgZ9FKHJQEnjJuKBcbFhMFzKu5slmN6NjlCuFnYJMQ8N4AZ6VrUyiRXlDtPKHkesuQ/MS913Nvdg==",
+      "version": "3.4.9",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.9.tgz",
+      "integrity": "sha512-1SEOvRr6sSdV5IDf9iC+NU4dhwdqzF4zKKq3sAbasUWHEM6lsMhX+eNN5gkPx1BvLFEnZQEUFbXnGj8Qlp83Pg==",
       "requires": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -14832,9 +14832,9 @@
       }
     },
     "terser": {
-      "version": "5.31.4",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.31.4.tgz",
-      "integrity": "sha512-3OU03GgblDgu0g+sdnsVzhBPxnjV+WJuMmocN1qBBZDQ3ia7jZQSAkePeKbPlYAejGXUTYe1CmSaUeV51mvaIw==",
+      "version": "5.31.5",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.31.5.tgz",
+      "integrity": "sha512-YPmas0L0rE1UyLL/llTWA0SiDOqIcAQYLeUj7cJYzXHlRTAnMSg9pPe4VJ5PlKvTrPQsdVFuiRiwyeNlYgwh2Q==",
       "requires": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.8.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12093,7 +12093,7 @@
       }
     },
     "pcic-react-leaflet-components": {
-      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#b8c0216f35a84c1c2e92cf9fd0be65b8dad5ca62",
+      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#b662af6f60562445c6373ffa7ecdba633afb3574",
       "from": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#add-BCVectorBaseMap",
       "requires": {
         "@testing-library/jest-dom": "^5.16.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12096,7 +12096,7 @@
       }
     },
     "pcic-react-leaflet-components": {
-      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#4dc65c34143185e08de7882cc4d045e334cd16b4",
+      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#7ae34d6c80bae45a821816df3194499222a4d39b",
       "from": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#add-BCVectorBaseMap",
       "requires": {
         "@testing-library/jest-dom": "^5.16.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12096,7 +12096,7 @@
       }
     },
     "pcic-react-leaflet-components": {
-      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#f859893542d8da4e24f8e5fe8642df28302d6730",
+      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#de53fb91862e1127fa51b70dd113ab272c05c2c7",
       "from": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#add-BCVectorBaseMap",
       "requires": {
         "@testing-library/jest-dom": "^5.16.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12096,7 +12096,7 @@
       }
     },
     "pcic-react-leaflet-components": {
-      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#2aa47a556dcf2641ddf3b73189eae69c292237f3",
+      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#f3ba95afe605c6cbe777de3e6916097039b21ee0",
       "from": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#add-BCVectorBaseMap",
       "requires": {
         "@testing-library/jest-dom": "^5.16.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12096,7 +12096,7 @@
       }
     },
     "pcic-react-leaflet-components": {
-      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#03af1b293fac0b7cf51a0d6b78e09a3c3826f1c8",
+      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#fd78f743bc5577263e9af38b3474f741facee10e",
       "from": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#add-BCVectorBaseMap",
       "requires": {
         "@testing-library/jest-dom": "^5.16.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4565,22 +4565,25 @@
       "integrity": "sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA=="
     },
     "babel-preset-current-node-syntax": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1.tgz",
-      "integrity": "sha512-M7LQ0bxarkxQoN+vz5aJPsLBn77n8QgTFmo8WK0/44auK2xlCXrYcUxHFxgU7qW5Yzw/CjmLRK2uJzaCd7LvqQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.1.0.tgz",
+      "integrity": "sha512-ldYss8SbBlWva1bs28q78Ju5Zq1F+8BrqBZZ0VFhLBvhh6lCpC2o3gDJi/5DRLs9FgYZCnmPYIVFU4lRXCkyUw==",
       "requires": {
         "@babel/plugin-syntax-async-generators": "^7.8.4",
         "@babel/plugin-syntax-bigint": "^7.8.3",
-        "@babel/plugin-syntax-class-properties": "^7.8.3",
-        "@babel/plugin-syntax-import-meta": "^7.8.3",
+        "@babel/plugin-syntax-class-properties": "^7.12.13",
+        "@babel/plugin-syntax-class-static-block": "^7.14.5",
+        "@babel/plugin-syntax-import-attributes": "^7.24.7",
+        "@babel/plugin-syntax-import-meta": "^7.10.4",
         "@babel/plugin-syntax-json-strings": "^7.8.3",
-        "@babel/plugin-syntax-logical-assignment-operators": "^7.8.3",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
         "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
-        "@babel/plugin-syntax-numeric-separator": "^7.8.3",
+        "@babel/plugin-syntax-numeric-separator": "^7.10.4",
         "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
         "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
         "@babel/plugin-syntax-optional-chaining": "^7.8.3",
-        "@babel/plugin-syntax-top-level-await": "^7.8.3"
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
+        "@babel/plugin-syntax-top-level-await": "^7.14.5"
       }
     },
     "babel-preset-jest": {
@@ -12093,7 +12096,7 @@
       }
     },
     "pcic-react-leaflet-components": {
-      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#3ea1feaccc54a771ef777e4a17a0c8487deef8df",
+      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#aa1ab567db4b0f33af7610019436bebc42dd1bd8",
       "from": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#add-BCVectorBaseMap",
       "requires": {
         "@testing-library/jest-dom": "^5.16.4",
@@ -14759,9 +14762,9 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
     },
     "tailwindcss": {
-      "version": "3.4.9",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.9.tgz",
-      "integrity": "sha512-1SEOvRr6sSdV5IDf9iC+NU4dhwdqzF4zKKq3sAbasUWHEM6lsMhX+eNN5gkPx1BvLFEnZQEUFbXnGj8Qlp83Pg==",
+      "version": "3.4.10",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.10.tgz",
+      "integrity": "sha512-KWZkVPm7yJRhdu4SRSl9d4AK2wM3a50UsvgHZO7xY77NQr2V+fIrEuoDGQcbvswWvFGbS2f6e+jC/6WJm1Dl0w==",
       "requires": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -14832,9 +14835,9 @@
       }
     },
     "terser": {
-      "version": "5.31.5",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.31.5.tgz",
-      "integrity": "sha512-YPmas0L0rE1UyLL/llTWA0SiDOqIcAQYLeUj7cJYzXHlRTAnMSg9pPe4VJ5PlKvTrPQsdVFuiRiwyeNlYgwh2Q==",
+      "version": "5.31.6",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.31.6.tgz",
+      "integrity": "sha512-PQ4DAriWzKj+qgehQ7LK5bQqCFNMmlhjR2PFFLuqGCpuCAauxemVBWwWOxo3UIwWQx8+Pr61Df++r76wDmkQBg==",
       "requires": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.8.2",
@@ -15465,9 +15468,9 @@
       }
     },
     "watchpack": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.1.tgz",
-      "integrity": "sha512-8wrBCMtVhqcXP2Sup1ctSkga6uc2Bx0IIvKyT7yTFier5AXHooSI+QyQQAtTb7+E0IUCCKyTFmXqdqgum2XWGg==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.2.tgz",
+      "integrity": "sha512-TnbFSbcOCcDgjZ4piURLCbJ3nJhznVh9kw6F6iokjiFPl8ONxe9A6nMDVXDiNbrSfLILs6vB07F7wLBrwPYzJw==",
       "requires": {
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12096,7 +12096,7 @@
       }
     },
     "pcic-react-leaflet-components": {
-      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#f1911044bc3d3898588f9f05b9de25de2151ccb8",
+      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#4e7ea371d7277e3eeacd57d679b31745b4fb1c84",
       "from": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#add-BCVectorBaseMap",
       "requires": {
         "@testing-library/jest-dom": "^5.16.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,25 +54,25 @@
       }
     },
     "@babel/compat-data": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.25.0.tgz",
-      "integrity": "sha512-P4fwKI2mjEb3ZU5cnMJzvRsRKGBUcs8jvxIoRmr6ufAY9Xk2Bz7JubRTTivkw55c7WQJfTECeqYVa+HZ0FzREg=="
+      "version": "7.25.2",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.25.2.tgz",
+      "integrity": "sha512-bYcppcpKBvX4znYaPEeFau03bp89ShqNMLs+rmdptMw+heSZh9+z84d2YG+K7cYLbWwzdjtDoW/uqZmPjulClQ=="
     },
     "@babel/core": {
-      "version": "7.24.9",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.9.tgz",
-      "integrity": "sha512-5e3FI4Q3M3Pbr21+5xJwCv6ZT6KmGkI0vw3Tozy5ODAQFTIWe37iT8Cr7Ice2Ntb+M3iSKCEWMB1MBgKrW3whg==",
+      "version": "7.25.2",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.25.2.tgz",
+      "integrity": "sha512-BBt3opiCOxUr9euZ5/ro/Xv8/V7yJ5bjYMqG/C1YAo8MIKAnumZalCN+msbci3Pigy4lIQfPUpfMM27HMGaYEA==",
       "requires": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.24.7",
-        "@babel/generator": "^7.24.9",
-        "@babel/helper-compilation-targets": "^7.24.8",
-        "@babel/helper-module-transforms": "^7.24.9",
-        "@babel/helpers": "^7.24.8",
-        "@babel/parser": "^7.24.8",
-        "@babel/template": "^7.24.7",
-        "@babel/traverse": "^7.24.8",
-        "@babel/types": "^7.24.9",
+        "@babel/generator": "^7.25.0",
+        "@babel/helper-compilation-targets": "^7.25.2",
+        "@babel/helper-module-transforms": "^7.25.2",
+        "@babel/helpers": "^7.25.0",
+        "@babel/parser": "^7.25.0",
+        "@babel/template": "^7.25.0",
+        "@babel/traverse": "^7.25.2",
+        "@babel/types": "^7.25.2",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -93,9 +93,9 @@
       }
     },
     "@babel/eslint-parser": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.25.0.tgz",
-      "integrity": "sha512-mlcTKuQAjczDRwWLIxv+Q925jaMUO8Jl5dxmWJSSGVYfZ4rKMp8daQvVC3rM1G2v8V+/fO0yIVTSLS+2zcB8rg==",
+      "version": "7.25.1",
+      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.25.1.tgz",
+      "integrity": "sha512-Y956ghgTT4j7rKesabkh5WeqgSFZVFwaPR0IWFm7KFHFmmJ4afbG49SmfW4S+GyRPx0Dy5jxEWA5t0rpxfElWg==",
       "requires": {
         "@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
         "eslint-visitor-keys": "^2.1.0",
@@ -154,11 +154,11 @@
       }
     },
     "@babel/helper-compilation-targets": {
-      "version": "7.24.8",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.24.8.tgz",
-      "integrity": "sha512-oU+UoqCHdp+nWVDkpldqIQL/i/bvAv53tRqLG/s+cOXxe66zOYLU7ar/Xs3LdmBihrUMEUhwu6dMZwbNOYDwvw==",
+      "version": "7.25.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.2.tgz",
+      "integrity": "sha512-U2U5LsSaZ7TAt3cfaymQ8WHh0pxvdHoEk6HVpaexxixjyEquMh0L0YNJNM6CTGKMXV1iksi0iZkGw4AcFkPaaw==",
       "requires": {
-        "@babel/compat-data": "^7.24.8",
+        "@babel/compat-data": "^7.25.2",
         "@babel/helper-validator-option": "^7.24.8",
         "browserslist": "^4.23.1",
         "lru-cache": "^5.1.1",
@@ -194,9 +194,9 @@
       }
     },
     "@babel/helper-create-regexp-features-plugin": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.25.0.tgz",
-      "integrity": "sha512-q0T+dknZS+L5LDazIP+02gEZITG5unzvb6yIjcmj5i0eFrs5ToBV2m2JGH4EsE/gtP8ygEGLGApBgRIZkTm7zg==",
+      "version": "7.25.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.25.2.tgz",
+      "integrity": "sha512-+wqVGP+DFmqwFD3EH6TMTfUNeqDehV3E/dl+Sd54eaXqm17tEUNbEIn4sVivVowbvUpOtIGxdo3GoXyDH9N/9g==",
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.24.7",
         "regexpu-core": "^5.3.1",
@@ -241,14 +241,14 @@
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.25.0.tgz",
-      "integrity": "sha512-bIkOa2ZJYn7FHnepzr5iX9Kmz8FjIz4UKzJ9zhX3dnYuVW0xul9RuR3skBfoLu+FPTQw90EHW9rJsSZhyLQ3fQ==",
+      "version": "7.25.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.25.2.tgz",
+      "integrity": "sha512-BjyRAbix6j/wv83ftcVJmBt72QtHI56C7JXZoG2xATiLpmoC7dpd8WnkikExHDVPpi/3qCmO6WY1EaXOluiecQ==",
       "requires": {
         "@babel/helper-module-imports": "^7.24.7",
         "@babel/helper-simple-access": "^7.24.7",
         "@babel/helper-validator-identifier": "^7.24.7",
-        "@babel/traverse": "^7.25.0"
+        "@babel/traverse": "^7.25.2"
       }
     },
     "@babel/helper-optimise-call-expression": {
@@ -790,11 +790,11 @@
       }
     },
     "@babel/plugin-transform-flow-strip-types": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.24.7.tgz",
-      "integrity": "sha512-cjRKJ7FobOH2eakx7Ja+KpJRj8+y+/SiB3ooYm/n2UJfxu0oEaOoxOinitkJcPqv9KxS0kxTGPUaR7L2XcXDXA==",
+      "version": "7.25.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.25.2.tgz",
+      "integrity": "sha512-InBZ0O8tew5V0K6cHcQ+wgxlrjOw1W4wDXLkOTjLRD8GYhTSkxTVBtdy3MMtvYBrbAWa1Qm3hNoTc1620Yj+Mg==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.24.7",
+        "@babel/helper-plugin-utils": "^7.24.8",
         "@babel/plugin-syntax-flow": "^7.24.7"
       }
     },
@@ -808,13 +808,13 @@
       }
     },
     "@babel/plugin-transform-function-name": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.25.0.tgz",
-      "integrity": "sha512-CQmfSnK14eYu82fu6GlCwRciHB7mp7oLN+DeyGDDwUr9cMwuSVviJKPXw/YcRYZdB1TdlLJWHHwXwnwD1WnCmQ==",
+      "version": "7.25.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.25.1.tgz",
+      "integrity": "sha512-TVVJVdW9RKMNgJJlLtHsKDTydjZAbwIsn6ySBPQaEAUU5+gVvlJt/9nRmqVbsV/IBanRjzWoaAQKLoamWVOUuA==",
       "requires": {
         "@babel/helper-compilation-targets": "^7.24.8",
         "@babel/helper-plugin-utils": "^7.24.8",
-        "@babel/traverse": "^7.25.0"
+        "@babel/traverse": "^7.25.1"
       }
     },
     "@babel/plugin-transform-json-strings": {
@@ -827,11 +827,11 @@
       }
     },
     "@babel/plugin-transform-literals": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.24.7.tgz",
-      "integrity": "sha512-vcwCbb4HDH+hWi8Pqenwnjy+UiklO4Kt1vfspcQYFhJdpthSnW8XvWGyDZWKNVrVbVViI/S7K9PDJZiUmP2fYQ==",
+      "version": "7.25.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.25.2.tgz",
+      "integrity": "sha512-HQI+HcTbm9ur3Z2DkO+jgESMAMcYLuN/A7NRw9juzxAezN9AvqvUTnpKP/9kkYANz6u7dFlAyOu44ejuGySlfw==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.24.7"
+        "@babel/helper-plugin-utils": "^7.24.8"
       }
     },
     "@babel/plugin-transform-logical-assignment-operators": {
@@ -1001,11 +1001,11 @@
       }
     },
     "@babel/plugin-transform-react-constant-elements": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.24.7.tgz",
-      "integrity": "sha512-7LidzZfUXyfZ8/buRW6qIIHBY8wAZ1OrY9c/wTr8YhZ6vMPo+Uc/CVFLYY1spZrEQlD4w5u8wjqk5NQ3OVqQKA==",
+      "version": "7.25.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.25.1.tgz",
+      "integrity": "sha512-SLV/giH/V4SmloZ6Dt40HjTGTAIkxn33TVIHxNGNvo8ezMhrxBkzisj4op1KZYPIOHFLqhv60OHvX+YRu4xbmQ==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.24.7"
+        "@babel/helper-plugin-utils": "^7.24.8"
       }
     },
     "@babel/plugin-transform-react-display-name": {
@@ -1017,15 +1017,15 @@
       }
     },
     "@babel/plugin-transform-react-jsx": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.24.7.tgz",
-      "integrity": "sha512-+Dj06GDZEFRYvclU6k4bme55GKBEWUmByM/eoKuqg4zTNQHiApWRhQph5fxQB2wAEFvRzL1tOEj1RJ19wJrhoA==",
+      "version": "7.25.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.25.2.tgz",
+      "integrity": "sha512-KQsqEAVBpU82NM/B/N9j9WOdphom1SZH3R+2V7INrQUH+V9EBFwZsEJl8eBIVeQE62FxJCc70jzEZwqU7RcVqA==",
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.24.7",
         "@babel/helper-module-imports": "^7.24.7",
-        "@babel/helper-plugin-utils": "^7.24.7",
+        "@babel/helper-plugin-utils": "^7.24.8",
         "@babel/plugin-syntax-jsx": "^7.24.7",
-        "@babel/types": "^7.24.7"
+        "@babel/types": "^7.25.2"
       }
     },
     "@babel/plugin-transform-react-jsx-development": {
@@ -1124,9 +1124,9 @@
       }
     },
     "@babel/plugin-transform-typescript": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.25.0.tgz",
-      "integrity": "sha512-LZicxFzHIw+Sa3pzgMgSz6gdpsdkfiMObHUzhSIrwKF0+/rP/nuR49u79pSS+zIFJ1FeGeqQD2Dq4QGFbOVvSw==",
+      "version": "7.25.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.25.2.tgz",
+      "integrity": "sha512-lBwRvjSmqiMYe/pS0+1gggjJleUJi7NzjvQ1Fkqtt69hBa/0t1YuW/MLQMAPixfwaQOHUXsd6jeU3Z+vdGv3+A==",
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.24.7",
         "@babel/helper-create-class-features-plugin": "^7.25.0",
@@ -1171,12 +1171,12 @@
       }
     },
     "@babel/preset-env": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.25.0.tgz",
-      "integrity": "sha512-vYAA8PrCOeZfG4D87hmw1KJ1BPubghXP1e2MacRFwECGNKL76dkA38JEwYllbvQCpf/kLxsTtir0b8MtxKoVCw==",
+      "version": "7.25.2",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.25.2.tgz",
+      "integrity": "sha512-Y2Vkwy3ITW4id9c6KXshVV/x5yCGK7VdJmKkzOzNsDZMojRKfSA/033rRbLqlRozmhRXCejxWHLSJOg/wUHfzw==",
       "requires": {
-        "@babel/compat-data": "^7.25.0",
-        "@babel/helper-compilation-targets": "^7.24.8",
+        "@babel/compat-data": "^7.25.2",
+        "@babel/helper-compilation-targets": "^7.25.2",
         "@babel/helper-plugin-utils": "^7.24.8",
         "@babel/helper-validator-option": "^7.24.8",
         "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.25.0",
@@ -1220,9 +1220,9 @@
         "@babel/plugin-transform-exponentiation-operator": "^7.24.7",
         "@babel/plugin-transform-export-namespace-from": "^7.24.7",
         "@babel/plugin-transform-for-of": "^7.24.7",
-        "@babel/plugin-transform-function-name": "^7.25.0",
+        "@babel/plugin-transform-function-name": "^7.25.1",
         "@babel/plugin-transform-json-strings": "^7.24.7",
-        "@babel/plugin-transform-literals": "^7.24.7",
+        "@babel/plugin-transform-literals": "^7.25.2",
         "@babel/plugin-transform-logical-assignment-operators": "^7.24.7",
         "@babel/plugin-transform-member-expression-literals": "^7.24.7",
         "@babel/plugin-transform-modules-amd": "^7.24.7",
@@ -1326,23 +1326,23 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.0.tgz",
-      "integrity": "sha512-ubALThHQy4GCf6mbb+5ZRNmLLCI7bJ3f8Q6LHBSRlSKSWj5a7dSUzJBLv3VuIhFrFPgjF4IzPF567YG/HSCdZA==",
+      "version": "7.25.2",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.2.tgz",
+      "integrity": "sha512-s4/r+a7xTnny2O6FcZzqgT6nE4/GHEdcqj4qAeglbUOh0TeglEfmNJFAd/OLoVtGd6ZhAO8GCVvCNUO5t/VJVQ==",
       "requires": {
         "@babel/code-frame": "^7.24.7",
         "@babel/generator": "^7.25.0",
         "@babel/parser": "^7.25.0",
         "@babel/template": "^7.25.0",
-        "@babel/types": "^7.25.0",
+        "@babel/types": "^7.25.2",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       }
     },
     "@babel/types": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.0.tgz",
-      "integrity": "sha512-LcnxQSsd9aXOIgmmSpvZ/1yo46ra2ESYyqLcryaBZOghxy5qqOBjvCWP5JfkI8yl9rlxRgdLTTMCQQRcN2hdCg==",
+      "version": "7.25.2",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.2.tgz",
+      "integrity": "sha512-YTnYtra7W9e6/oAZEHj0bJehPRUlLH9/fbpT5LfB0NhQXyALCRkRs3zH9v07IYhkgpqX6Z78FnuccZr/l4Fs4Q==",
       "requires": {
         "@babel/helper-string-parser": "^7.24.8",
         "@babel/helper-validator-identifier": "^7.24.7",
@@ -2976,9 +2976,9 @@
       }
     },
     "@rushstack/eslint-patch": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.10.3.tgz",
-      "integrity": "sha512-qC/xYId4NMebE6w/V33Fh9gWxLgURiNYgVNObbJl2LZv0GUUItCcCqC5axQSwRaAgaxl2mELq1rMzlswaQ0Zxg=="
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.10.4.tgz",
+      "integrity": "sha512-WJgX9nzTqknM393q1QJDJmoW28kUfEnybeTfVNcNAPnIx210RXm2DiXiHzfNPJNIUUb1tJnz/l4QGtJ30PgWmA=="
     },
     "@sinclair/typebox": {
       "version": "0.27.8",
@@ -3522,11 +3522,11 @@
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w=="
     },
     "@types/node": {
-      "version": "20.14.12",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.12.tgz",
-      "integrity": "sha512-r7wNXakLeSsGT0H1AU863vS2wa5wBOK4bWMjZz2wj+8nBx+m5PeIn0k8AloSLpRuiwdRQZwarZqHE4FNArPuJQ==",
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.0.0.tgz",
+      "integrity": "sha512-VT7KSYudcPOzP5Q0wfbowyNLaVR8QWUdw+088uFWwfvpY6uCWaXpqV6ieLAu9WBcnTa7H4Z5RLK8I5t2FuOcqw==",
       "requires": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.11.1"
       }
     },
     "@types/node-forge": {
@@ -3676,9 +3676,9 @@
       "integrity": "sha512-D1XC7WK8K+zZEveUPY+cf4+kgauk8N4eHr/XIHXGlGYkHLud6hK9lYfZk1ry1TNh798cZUCgb6MqGEG8DkJt6Q=="
     },
     "@types/ws": {
-      "version": "8.5.11",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.11.tgz",
-      "integrity": "sha512-4+q7P5h3SpJxaBft0Dzpbr6lmMaqh0Jr2tbhJZ/luAwvD7ohSCniYkwz/pLxuT2h0EOa6QADgJj1Ko+TzRfZ+w==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.12.tgz",
+      "integrity": "sha512-3tPRkv1EtkDpzlgyKyI8pGsGZAGPEaXeu0DOj5DI25Ja91bdAYddYHbADRYVrZMRbfW+1l5YwXVDKohDJNQxkQ==",
       "requires": {
         "@types/node": "*"
       }
@@ -4300,9 +4300,9 @@
       }
     },
     "axe-core": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.9.1.tgz",
-      "integrity": "sha512-QbUdXJVTpvUTHU7871ppZkdOLBeGUKBQWHkHrvN2V9IQWGMt61zf3B45BtzjxEJzYuj0JBjBZP/hmYS/R9pmAw=="
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.0.tgz",
+      "integrity": "sha512-Mr2ZakwQ7XUAjp7pAwQWRhhK8mQQ6JAaNWSjmjxil0R8BPioMtQsTLOolGYkji1rcL++3dCqZA3zWqpT+9Ew6g=="
     },
     "axios": {
       "version": "0.28.1",
@@ -4857,9 +4857,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001643",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001643.tgz",
-      "integrity": "sha512-ERgWGNleEilSrHM6iUz/zJNSQTP8Mr21wDWpdgvRwcTXGAq6jMtOUPP4dqFPTdKqZ2wKTdtB+uucZ3MRpAUSmg=="
+      "version": "1.0.30001644",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001644.tgz",
+      "integrity": "sha512-YGvlOZB4QhZuiis+ETS0VXR+MExbFf4fZYYeMTEE0aTQd/RdIjkTyZjLrbYVKnHzppDvnOhritRVv+i7Go6mHw=="
     },
     "case-sensitive-paths-webpack-plugin": {
       "version": "2.4.0",
@@ -5789,9 +5789,9 @@
       }
     },
     "debug": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
-      "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
+      "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
       "requires": {
         "ms": "2.1.2"
       }
@@ -6100,9 +6100,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.2.tgz",
-      "integrity": "sha512-kc4r3U3V3WLaaZqThjYz/Y6z8tJe+7K0bbjUVo3i+LWIypVdMx5nXCkwRe6SWbY6ILqLdc1rKcKmr3HoH7wjSQ=="
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.3.tgz",
+      "integrity": "sha512-QNdYSS5i8D9axWp/6XIezRObRHqaav/ur9z1VzCDUCH1XIFOr9WQk5xmgunhsTpjjgDy3oLxO/WMOVZlpUQrlA=="
     },
     "emittery": {
       "version": "0.8.1",
@@ -12090,7 +12090,7 @@
       }
     },
     "pcic-react-leaflet-components": {
-      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#0533638a557e23e4cb59e64a163788786d86a6db",
+      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#e17e93d5b0a7ec7d1ad9c1577344f1cba9955bf8",
       "from": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#add-BCVectorBaseMap",
       "requires": {
         "@testing-library/jest-dom": "^5.16.4",
@@ -15189,9 +15189,9 @@
       "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
     },
     "undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.11.1.tgz",
+      "integrity": "sha512-mIDEX2ek50x0OlRgxryxsenE5XaQD4on5U2inY7RApK3SOJpofyw7uW2AyfMKkhAxXIceo2DeWGVGwyvng1GNQ=="
     },
     "unherit": {
       "version": "1.1.3",
@@ -15726,12 +15726,12 @@
       }
     },
     "which-builtin-type": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.1.3.tgz",
-      "integrity": "sha512-YmjsSMDBYsM1CaFiayOVT06+KJeXf0o5M/CAd4o1lTadFAtacTUM49zoYxr/oroopFDfhvN6iEcBxUyc3gvKmw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.1.4.tgz",
+      "integrity": "sha512-bppkmBSsHFmIMSl8BO9TbsyzsvGjVoppt8xUiGzwiu/bhDCGxnpOKCxgqj6GuyHE0mINMDecBFPlOm2hzY084w==",
       "requires": {
-        "function.prototype.name": "^1.1.5",
-        "has-tostringtag": "^1.0.0",
+        "function.prototype.name": "^1.1.6",
+        "has-tostringtag": "^1.0.2",
         "is-async-function": "^2.0.0",
         "is-date-object": "^1.0.5",
         "is-finalizationregistry": "^1.0.2",
@@ -15740,8 +15740,8 @@
         "is-weakref": "^1.0.2",
         "isarray": "^2.0.5",
         "which-boxed-primitive": "^1.0.2",
-        "which-collection": "^1.0.1",
-        "which-typed-array": "^1.1.9"
+        "which-collection": "^1.0.2",
+        "which-typed-array": "^1.1.15"
       }
     },
     "which-collection": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12096,7 +12096,7 @@
       }
     },
     "pcic-react-leaflet-components": {
-      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#153a838dfd06fdb036a7d617c01ea7b8cc2c010b",
+      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#011fb444a61be1de3afa9ca1a4372699fec28fb1",
       "from": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#add-BCVectorBaseMap",
       "requires": {
         "@testing-library/jest-dom": "^5.16.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11438,6 +11438,24 @@
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
       "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA=="
     },
+    "leaflet.vectorgrid": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/leaflet.vectorgrid/-/leaflet.vectorgrid-1.3.0.tgz",
+      "integrity": "sha512-kWmj1pKM+MVdo/7Mg5zsB3YrGZvo/uIuiANV9MvWUFOG+Y2xAJzrteDhoIcCgTjHSSRJ36xdeGdIQVhuWjnCZw==",
+      "requires": {
+        "pbf": "^3.0.2",
+        "topojson-client": "^2.1.0",
+        "vector-tile": "^1.3.0",
+        "whatwg-fetch": "^2.0.3"
+      },
+      "dependencies": {
+        "whatwg-fetch": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+          "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
+        }
+      }
+    },
     "lethargy": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/lethargy/-/lethargy-1.0.9.tgz",
@@ -12181,6 +12199,15 @@
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
     },
+    "pbf": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.3.0.tgz",
+      "integrity": "sha512-XDF38WCH3z5OV/OVa8GKUNtLAyneuzbCisx7QUCF8Q6Nutx0WnJrQe5O+kOtBlLfRNUws98Y58Lblp+NJG5T4Q==",
+      "requires": {
+        "ieee754": "^1.1.12",
+        "resolve-protobuf-schema": "^2.1.0"
+      }
+    },
     "pcic-react-components": {
       "version": "git+https://git@github.com/pacificclimate/pcic-react-components.git#14d818e05e4686f8e6d05a76fc2f6c4ee793f6d8",
       "from": "git+https://git@github.com/pacificclimate/pcic-react-components.git#3.1.0",
@@ -12201,12 +12228,13 @@
       }
     },
     "pcic-react-leaflet-components": {
-      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#bf88217948ce6fdd8165b8bbbd0d4fc29939aecc",
-      "from": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#3.0.1",
+      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#2d6b94b55a3eac746d1c9205288dbdb46bfcf30c",
+      "from": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#add-BCVectorBaseMap",
       "requires": {
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^13.3.0",
         "@testing-library/user-event": "^14.2.1",
+        "leaflet.vectorgrid": "^1.3.0",
         "lodash": "^4.17.21",
         "proj4": "^2.8.0",
         "proj4leaflet": "^1.0.2",
@@ -12288,6 +12316,11 @@
           "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ=="
         }
       }
+    },
+    "point-geometry": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/point-geometry/-/point-geometry-0.0.0.tgz",
+      "integrity": "sha512-tXK8bY2l3/CPkyO7+UbOWbVjCpKoYY4t6uY3AYYy4Bagd4Z942gLeQOgtHICwBwgPf8dI6fw4VqKwzSNgvlw4A=="
     },
     "possible-typed-array-names": {
       "version": "1.0.0",
@@ -13112,6 +13145,11 @@
         "warning": "^4.0.0"
       }
     },
+    "protocol-buffers-schema": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
+      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw=="
+    },
     "proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -13930,6 +13968,14 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
+    },
+    "resolve-protobuf-schema": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
+      "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
+      "requires": {
+        "protocol-buffers-schema": "^3.3.1"
+      }
     },
     "resolve-url-loader": {
       "version": "4.0.0",
@@ -15000,6 +15046,14 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
     },
+    "topojson-client": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-2.1.0.tgz",
+      "integrity": "sha512-mxXNa6imbsrWXqUKF7iwGl2TkrshZ7dwQF+KuAB4hX9wTmfecNzqSjMmQZNhP2Ztvfwx8rKt0BfQfHF+ki6hQw==",
+      "requires": {
+        "commander": "2"
+      }
+    },
     "touch": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/touch/-/touch-2.0.2.tgz",
@@ -15431,6 +15485,14 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
+    },
+    "vector-tile": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/vector-tile/-/vector-tile-1.3.0.tgz",
+      "integrity": "sha512-ECpYpDhbgTSGIRwaf4bLbiDHcUHDM+LGrBOmV1tdG+Lde8vajJtywP5vGFmMj0Z3cApTV0+9sLWgBCVsRuoAKQ==",
+      "requires": {
+        "point-geometry": "0.0.0"
+      }
     },
     "vfile": {
       "version": "2.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12096,7 +12096,7 @@
       }
     },
     "pcic-react-leaflet-components": {
-      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#d020aba532125695ad34fe756ee236a96a540e77",
+      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#ddcbefa230ca2f0cd7cf205f175dc5355088c28c",
       "from": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#add-BCVectorBaseMap",
       "requires": {
         "@testing-library/jest-dom": "^5.16.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3525,9 +3525,9 @@
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w=="
     },
     "@types/node": {
-      "version": "22.4.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.4.0.tgz",
-      "integrity": "sha512-49AbMDwYUz7EXxKU/r7mXOsxwFr4BYbvB7tWYxVuLdb2ibd30ijjXINSMAHiEEZk5PCRBmW1gUeisn2VMKt3cQ==",
+      "version": "22.4.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.4.1.tgz",
+      "integrity": "sha512-1tbpb9325+gPnKK0dMm+/LMriX0vKxf6RnB0SZUqfyVkQ4fMgUSySqhxE/y8Jvs4NyF1yHzTfG9KlnkIODxPKg==",
       "requires": {
         "undici-types": "~6.19.2"
       }
@@ -6106,9 +6106,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.5.9",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.9.tgz",
-      "integrity": "sha512-HfkT8ndXR0SEkU8gBQQM3rz035bpE/hxkZ1YIt4KJPEFES68HfIU6LzKukH0H794Lm83WJtkSAMfEToxCs15VA=="
+      "version": "1.5.11",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.11.tgz",
+      "integrity": "sha512-R1CccCDYqndR25CaXFd6hp/u9RaaMcftMkphmvuepXr5b1vfLkRml6aWVeBhXJ7rbevHkKEMJtz8XqPf7ffmew=="
     },
     "emittery": {
       "version": "0.8.1",
@@ -11592,9 +11592,9 @@
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="
     },
     "mini-css-extract-plugin": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.9.0.tgz",
-      "integrity": "sha512-Zs1YsZVfemekSZG+44vBsYTLQORkPMwnlv+aehcxK/NLKC+EGhDB39/YePYYqx/sTk6NnYpuqikhSn7+JIevTA==",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.9.1.tgz",
+      "integrity": "sha512-+Vyi+GCCOHnrJ2VPS+6aPoXN2k2jgUzDRhTFLjjTBn23qyXJXkjUWQgTL+mXpF5/A8ixLdCc6kWsoeOjKGejKQ==",
       "requires": {
         "schema-utils": "^4.0.0",
         "tapable": "^2.2.1"
@@ -12096,7 +12096,7 @@
       }
     },
     "pcic-react-leaflet-components": {
-      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#17bf14db91327be6d897a57e9d464952d2db3a2b",
+      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#7a22b7d0149357ea8f25c35d155c5899d6516756",
       "from": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#add-BCVectorBaseMap",
       "requires": {
         "@testing-library/jest-dom": "^5.16.4",
@@ -15195,9 +15195,9 @@
       "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
     },
     "undici-types": {
-      "version": "6.19.6",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.6.tgz",
-      "integrity": "sha512-e/vggGopEfTKSvj4ihnOLTsqhrKRN3LeO6qSN/GxohhuRv8qH9bNQ4B8W7e/vFL+0XTnmHPB4/kegunZGA4Org=="
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
     },
     "unherit": {
       "version": "1.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6106,9 +6106,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.5.8",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.8.tgz",
-      "integrity": "sha512-4Nx0gP2tPNBLTrFxBMHpkQbtn2hidPVr/+/FTtcCiBYTucqc70zRyVZiOLj17Ui3wTO7SQ1/N+hkHYzJjBzt6A=="
+      "version": "1.5.9",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.9.tgz",
+      "integrity": "sha512-HfkT8ndXR0SEkU8gBQQM3rz035bpE/hxkZ1YIt4KJPEFES68HfIU6LzKukH0H794Lm83WJtkSAMfEToxCs15VA=="
     },
     "emittery": {
       "version": "0.8.1",
@@ -12096,7 +12096,7 @@
       }
     },
     "pcic-react-leaflet-components": {
-      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#7ae34d6c80bae45a821816df3194499222a4d39b",
+      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#d913ea6e2a978b01481199f6db45f2f457652575",
       "from": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#add-BCVectorBaseMap",
       "requires": {
         "@testing-library/jest-dom": "^5.16.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12093,7 +12093,7 @@
       }
     },
     "pcic-react-leaflet-components": {
-      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#f262da820ae6a8a3bc96422902bf44b4b90c0ac3",
+      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#127dcfaffc4e2a66c115cd024d4cf4f2d8eb82aa",
       "from": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#add-BCVectorBaseMap",
       "requires": {
         "@testing-library/jest-dom": "^5.16.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12093,7 +12093,7 @@
       }
     },
     "pcic-react-leaflet-components": {
-      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#9f25136aec31d126d08d30e4ad6dd98b79e99e47",
+      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#5c26589e4d4176a3126e3cc5e2e27be364b781b8",
       "from": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#add-BCVectorBaseMap",
       "requires": {
         "@testing-library/jest-dom": "^5.16.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12093,7 +12093,7 @@
       }
     },
     "pcic-react-leaflet-components": {
-      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#5c26589e4d4176a3126e3cc5e2e27be364b781b8",
+      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#f072d08fd7a5982a48ed6af61d25393e6f8ce170",
       "from": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#add-BCVectorBaseMap",
       "requires": {
         "@testing-library/jest-dom": "^5.16.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12096,7 +12096,7 @@
       }
     },
     "pcic-react-leaflet-components": {
-      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#9d65ab22491ddf58d724b99f37ed4c5233c593bd",
+      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#599ffe817de0f7d1416ceba264df999eb82d3b11",
       "from": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#add-BCVectorBaseMap",
       "requires": {
         "@testing-library/jest-dom": "^5.16.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12096,7 +12096,7 @@
       }
     },
     "pcic-react-leaflet-components": {
-      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#701bf40345283dc2147ec1d5a3894fd8181b5016",
+      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#f859893542d8da4e24f8e5fe8642df28302d6730",
       "from": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#add-BCVectorBaseMap",
       "requires": {
         "@testing-library/jest-dom": "^5.16.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4267,9 +4267,9 @@
       "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ=="
     },
     "async": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
-      "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg=="
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="
     },
     "asynckit": {
       "version": "0.4.0",
@@ -5144,22 +5144,22 @@
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
     },
     "core-js": {
-      "version": "3.38.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.38.0.tgz",
-      "integrity": "sha512-XPpwqEodRljce9KswjZShh95qJ1URisBeKCjUdq27YdenkslVe7OO0ZJhlYXAChW7OhXaRLl8AAba7IBfoIHug=="
+      "version": "3.38.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.38.1.tgz",
+      "integrity": "sha512-OP35aUorbU3Zvlx7pjsFdu1rGNnD4pgw/CWoYzRY3t2EzoVT7shKHY1dlAy3f41cGIO7ZDPQimhGFTlEYkG/Hw=="
     },
     "core-js-compat": {
-      "version": "3.38.0",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.38.0.tgz",
-      "integrity": "sha512-75LAicdLa4OJVwFxFbQR3NdnZjNgX6ILpVcVzcC4T2smerB5lELMrJQQQoWV6TiuC/vlaFqgU2tKQx9w5s0e0A==",
+      "version": "3.38.1",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.38.1.tgz",
+      "integrity": "sha512-JRH6gfXxGmrzF3tZ57lFx97YARxCXPaMzPo6jELZhv88pBH5VXpQ+y0znKGlFnzuaihqhLbefxSJxWJMPtfDzw==",
       "requires": {
         "browserslist": "^4.23.3"
       }
     },
     "core-js-pure": {
-      "version": "3.38.0",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.0.tgz",
-      "integrity": "sha512-8balb/HAXo06aHP58mZMtXgD8vcnXz9tUDePgqBgJgKdmTlMt+jw3ujqniuBDQXMvTzxnMpxHFeuSM3g1jWQuQ=="
+      "version": "3.38.1",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
+      "integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ=="
     },
     "core-util-is": {
       "version": "1.0.3",
@@ -6106,9 +6106,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.5.11",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.11.tgz",
-      "integrity": "sha512-R1CccCDYqndR25CaXFd6hp/u9RaaMcftMkphmvuepXr5b1vfLkRml6aWVeBhXJ7rbevHkKEMJtz8XqPf7ffmew=="
+      "version": "1.5.12",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.12.tgz",
+      "integrity": "sha512-tIhPkdlEoCL1Y+PToq3zRNehUaKp3wBX/sr7aclAWdIWjvqAe/Im/H0SiCM4c1Q8BLPHCdoJTol+ZblflydehA=="
     },
     "emittery": {
       "version": "0.8.1",
@@ -12096,7 +12096,7 @@
       }
     },
     "pcic-react-leaflet-components": {
-      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#d041cb8dd9809f3530ae34ed12b2de362a077b18",
+      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#15bb605b419d4c3a3876ca6b0b3563e58bdca858",
       "from": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#add-BCVectorBaseMap",
       "requires": {
         "@testing-library/jest-dom": "^5.16.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12093,7 +12093,7 @@
       }
     },
     "pcic-react-leaflet-components": {
-      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#7dded99f7531755f66c96562d1291d36660c53ca",
+      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#bdec5b2a1fe5a86599ef89e5d1e4292bacc385b2",
       "from": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#add-BCVectorBaseMap",
       "requires": {
         "@testing-library/jest-dom": "^5.16.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12093,7 +12093,7 @@
       }
     },
     "pcic-react-leaflet-components": {
-      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#224b08b272bfee192982f7e02b692e6193cd93eb",
+      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#7dded99f7531755f66c96562d1291d36660c53ca",
       "from": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#add-BCVectorBaseMap",
       "requires": {
         "@testing-library/jest-dom": "^5.16.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12093,7 +12093,7 @@
       }
     },
     "pcic-react-leaflet-components": {
-      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#f54bc17750b2459bfefb25179f8019e2c562e493",
+      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#392aca4844c554496792ff3d39408eea592eb8cd",
       "from": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#add-BCVectorBaseMap",
       "requires": {
         "@testing-library/jest-dom": "^5.16.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12093,7 +12093,7 @@
       }
     },
     "pcic-react-leaflet-components": {
-      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#f1f9273a8a2765d68c9b4f193ed38809912a959b",
+      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#990ba96c9edbd1a0315a087c03303b0380f9f314",
       "from": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#add-BCVectorBaseMap",
       "requires": {
         "@testing-library/jest-dom": "^5.16.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12096,7 +12096,7 @@
       }
     },
     "pcic-react-leaflet-components": {
-      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#0ce6ce5e5a3b231900f950cc48d6b8435e567c57",
+      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#17bf14db91327be6d897a57e9d464952d2db3a2b",
       "from": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#add-BCVectorBaseMap",
       "requires": {
         "@testing-library/jest-dom": "^5.16.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3595,9 +3595,9 @@
       }
     },
     "@types/react-transition-group": {
-      "version": "4.4.10",
-      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.10.tgz",
-      "integrity": "sha512-hT/+s0VQs2ojCX823m60m5f0sL5idt9SO6Tj6Dg+rdphGPIeJbJ6CxvBYkgkGKrYeDjvIpKTR38UzmtHJOGW3Q==",
+      "version": "4.4.11",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.11.tgz",
+      "integrity": "sha512-RM05tAniPZ5DZPzzNFP+DmrcOdD0efDUxMy3145oljWSl3x9ZV5vhme98gTxFrj2lhXvmGNnUiuDyJgY9IKkNA==",
       "requires": {
         "@types/react": "*"
       }
@@ -6103,9 +6103,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.5.tgz",
-      "integrity": "sha512-QR7/A7ZkMS8tZuoftC/jfqNkZLQO779SSW3YuZHP4eXpj3EffGLFcB/Xu9AAZQzLccTiCV+EmUo3ha4mQ9wnlA=="
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.6.tgz",
+      "integrity": "sha512-jwXWsM5RPf6j9dPYzaorcBSUg6AiqocPEyMpkchkvntaH9HGfOOMZwxMJjDY/XEs3T5dM7uyH1VhRMkqUU9qVw=="
     },
     "emittery": {
       "version": "0.8.1",
@@ -7890,9 +7890,9 @@
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
     "ignore": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
-      "integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw=="
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="
     },
     "immer": {
       "version": "9.0.21",
@@ -12093,7 +12093,7 @@
       }
     },
     "pcic-react-leaflet-components": {
-      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#990ba96c9edbd1a0315a087c03303b0380f9f314",
+      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#e08b28a41d3c81665f73269ca08f0a20993d1496",
       "from": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#add-BCVectorBaseMap",
       "requires": {
         "@testing-library/jest-dom": "^5.16.4",
@@ -12772,9 +12772,9 @@
       }
     },
     "postcss-selector-parser": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.1.tgz",
-      "integrity": "sha512-b4dlw/9V8A71rLIDsSwVmak9z2DuBUB7CA1/wSdelNEzqsjoSPeADTWNO09lpH49Diy3/JIZ2bSPB1dI3LJCHg==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
       "requires": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -12958,9 +12958,9 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "proj4": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.11.0.tgz",
-      "integrity": "sha512-SasuTkAx8HnWQHfIyhkdUNJorSJqINHAN3EyMWYiQRVorftz9DHz650YraFgczwgtHOxqnfuDxSNv3C8MUnHeg==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.12.0.tgz",
+      "integrity": "sha512-cQJxcVX7+fmAhOxoazKgk76GkGYQ5HcLod4rdy2MizhPvLdrZQJThxsHoz/TjjdxUvTm/rbozMgE0q9mdXKWIw==",
       "requires": {
         "mgrs": "1.0.0",
         "wkt-parser": "^1.3.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12096,7 +12096,7 @@
       }
     },
     "pcic-react-leaflet-components": {
-      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#bfef0790d8815978a53b26da9549e3acae229103",
+      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#d020aba532125695ad34fe756ee236a96a540e77",
       "from": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#add-BCVectorBaseMap",
       "requires": {
         "@testing-library/jest-dom": "^5.16.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3571,9 +3571,9 @@
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="
     },
     "@types/react": {
-      "version": "18.3.3",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
-      "integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
+      "version": "18.3.4",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.4.tgz",
+      "integrity": "sha512-J7W30FTdfCxDDjmfRM+/JqLHBIyl7xUIp9kwK637FGmY7+mkSFSe6L4jpZzhj5QMfLssSDP4/i75AKkrdC7/Jw==",
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -12096,7 +12096,7 @@
       }
     },
     "pcic-react-leaflet-components": {
-      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#b005f069d8c0cf1896f02940b3955d13af66485d",
+      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#0379024e4878534ec95e7d5a971dc2d0f4621986",
       "from": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#add-BCVectorBaseMap",
       "requires": {
         "@testing-library/jest-dom": "^5.16.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12090,7 +12090,7 @@
       }
     },
     "pcic-react-leaflet-components": {
-      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#70bba72eda6522b3eee758ff3821ae52ddeb1585",
+      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#0533638a557e23e4cb59e64a163788786d86a6db",
       "from": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#add-BCVectorBaseMap",
       "requires": {
         "@testing-library/jest-dom": "^5.16.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,9 +54,9 @@
       }
     },
     "@babel/compat-data": {
-      "version": "7.24.9",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.24.9.tgz",
-      "integrity": "sha512-e701mcfApCJqMMueQI0Fb68Amflj83+dvAvHawoBpAz+GDjCIyGHzNwnefjsWJ3xiYAqqiQFoWbspGYBdb2/ng=="
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.25.0.tgz",
+      "integrity": "sha512-P4fwKI2mjEb3ZU5cnMJzvRsRKGBUcs8jvxIoRmr6ufAY9Xk2Bz7JubRTTivkw55c7WQJfTECeqYVa+HZ0FzREg=="
     },
     "@babel/core": {
       "version": "7.24.9",
@@ -93,9 +93,9 @@
       }
     },
     "@babel/eslint-parser": {
-      "version": "7.24.8",
-      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.24.8.tgz",
-      "integrity": "sha512-nYAikI4XTGokU2QX7Jx+v4rxZKhKivaQaREZjuW3mrJrbdWJ5yUfohnoUULge+zEEaKjPYNxhoRgUKktjXtbwA==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.25.0.tgz",
+      "integrity": "sha512-mlcTKuQAjczDRwWLIxv+Q925jaMUO8Jl5dxmWJSSGVYfZ4rKMp8daQvVC3rM1G2v8V+/fO0yIVTSLS+2zcB8rg==",
       "requires": {
         "@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
         "eslint-visitor-keys": "^2.1.0",
@@ -115,11 +115,11 @@
       }
     },
     "@babel/generator": {
-      "version": "7.24.10",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.10.tgz",
-      "integrity": "sha512-o9HBZL1G2129luEUlG1hB4N/nlYNWHnpwlND9eOMclRqqu1YDy2sSYVCFUZwl8I1Gxh+QSRrP2vD7EpUmFVXxg==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.0.tgz",
+      "integrity": "sha512-3LEEcj3PVW8pW2R1SR1M89g/qrYk/m/mB/tLqn7dn4sbBUQyTqnlod+II2U4dqiGtUmkcnAmkMDralTFZttRiw==",
       "requires": {
-        "@babel/types": "^7.24.9",
+        "@babel/types": "^7.25.0",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^2.5.1"
@@ -173,18 +173,16 @@
       }
     },
     "@babel/helper-create-class-features-plugin": {
-      "version": "7.24.8",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.24.8.tgz",
-      "integrity": "sha512-4f6Oqnmyp2PP3olgUMmOwC3akxSm5aBYraQ6YDdKy7NcAMkDECHWG0DEnV6M2UAkERgIBhYt8S27rURPg7SxWA==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.25.0.tgz",
+      "integrity": "sha512-GYM6BxeQsETc9mnct+nIIpf63SAyzvyYN7UB/IlTyd+MBg06afFGp0mIeUqGyWgS2mxad6vqbMrHVlaL3m70sQ==",
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.24.7",
-        "@babel/helper-environment-visitor": "^7.24.7",
-        "@babel/helper-function-name": "^7.24.7",
         "@babel/helper-member-expression-to-functions": "^7.24.8",
         "@babel/helper-optimise-call-expression": "^7.24.7",
-        "@babel/helper-replace-supers": "^7.24.7",
+        "@babel/helper-replace-supers": "^7.25.0",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.24.7",
-        "@babel/helper-split-export-declaration": "^7.24.7",
+        "@babel/traverse": "^7.25.0",
         "semver": "^6.3.1"
       },
       "dependencies": {
@@ -196,9 +194,9 @@
       }
     },
     "@babel/helper-create-regexp-features-plugin": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.24.7.tgz",
-      "integrity": "sha512-03TCmXy2FtXJEZfbXDTSqq1fRJArk7lX9DOFC/47VthYcxyIOx+eXQmdo6DOQvrbpIix+KfXwvuXdFDZHxt+rA==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.25.0.tgz",
+      "integrity": "sha512-q0T+dknZS+L5LDazIP+02gEZITG5unzvb6yIjcmj5i0eFrs5ToBV2m2JGH4EsE/gtP8ygEGLGApBgRIZkTm7zg==",
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.24.7",
         "regexpu-core": "^5.3.1",
@@ -224,31 +222,6 @@
         "resolve": "^1.14.2"
       }
     },
-    "@babel/helper-environment-visitor": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.24.7.tgz",
-      "integrity": "sha512-DoiN84+4Gnd0ncbBOM9AZENV4a5ZiL39HYMyZJGZ/AZEykHYdJw0wW3kdcsh9/Kn+BRXHLkkklZ51ecPKmI1CQ==",
-      "requires": {
-        "@babel/types": "^7.24.7"
-      }
-    },
-    "@babel/helper-function-name": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.24.7.tgz",
-      "integrity": "sha512-FyoJTsj/PEUWu1/TYRiXTIHc8lbw+TDYkZuoE43opPS5TrI7MyONBE1oNvfguEXAD9yhQRrVBnXdXzSLQl9XnA==",
-      "requires": {
-        "@babel/template": "^7.24.7",
-        "@babel/types": "^7.24.7"
-      }
-    },
-    "@babel/helper-hoist-variables": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.24.7.tgz",
-      "integrity": "sha512-MJJwhkoGy5c4ehfoRyrJ/owKeMl19U54h27YYftT0o2teQ3FJ3nQUf/I3LlJsX4l3qlw7WRXUmiyajvHXoTubQ==",
-      "requires": {
-        "@babel/types": "^7.24.7"
-      }
-    },
     "@babel/helper-member-expression-to-functions": {
       "version": "7.24.8",
       "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.24.8.tgz",
@@ -268,15 +241,14 @@
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.24.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.24.9.tgz",
-      "integrity": "sha512-oYbh+rtFKj/HwBQkFlUzvcybzklmVdVV3UU+mN7n2t/q3yGHbuVdNxyFvSBO1tfvjyArpHNcWMAzsSPdyI46hw==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.25.0.tgz",
+      "integrity": "sha512-bIkOa2ZJYn7FHnepzr5iX9Kmz8FjIz4UKzJ9zhX3dnYuVW0xul9RuR3skBfoLu+FPTQw90EHW9rJsSZhyLQ3fQ==",
       "requires": {
-        "@babel/helper-environment-visitor": "^7.24.7",
         "@babel/helper-module-imports": "^7.24.7",
         "@babel/helper-simple-access": "^7.24.7",
-        "@babel/helper-split-export-declaration": "^7.24.7",
-        "@babel/helper-validator-identifier": "^7.24.7"
+        "@babel/helper-validator-identifier": "^7.24.7",
+        "@babel/traverse": "^7.25.0"
       }
     },
     "@babel/helper-optimise-call-expression": {
@@ -293,23 +265,23 @@
       "integrity": "sha512-FFWx5142D8h2Mgr/iPVGH5G7w6jDn4jUSpZTyDnQO0Yn7Ks2Kuz6Pci8H6MPCoUJegd/UZQ3tAvfLCxQSnWWwg=="
     },
     "@babel/helper-remap-async-to-generator": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.24.7.tgz",
-      "integrity": "sha512-9pKLcTlZ92hNZMQfGCHImUpDOlAgkkpqalWEeftW5FBya75k8Li2ilerxkM/uBEj01iBZXcCIB/bwvDYgWyibA==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.25.0.tgz",
+      "integrity": "sha512-NhavI2eWEIz/H9dbrG0TuOicDhNexze43i5z7lEqwYm0WEZVTwnPpA0EafUTP7+6/W79HWIP2cTe3Z5NiSTVpw==",
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.24.7",
-        "@babel/helper-environment-visitor": "^7.24.7",
-        "@babel/helper-wrap-function": "^7.24.7"
+        "@babel/helper-wrap-function": "^7.25.0",
+        "@babel/traverse": "^7.25.0"
       }
     },
     "@babel/helper-replace-supers": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.24.7.tgz",
-      "integrity": "sha512-qTAxxBM81VEyoAY0TtLrx1oAEJc09ZK67Q9ljQToqCnA+55eNwCORaxlKyu+rNfX86o8OXRUSNUnrtsAZXM9sg==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.25.0.tgz",
+      "integrity": "sha512-q688zIvQVYtZu+i2PsdIu/uWGRpfxzr5WESsfpShfZECkO+d2o+WROWezCi/Q6kJ0tfPa5+pUGUlfx2HhrA3Bg==",
       "requires": {
-        "@babel/helper-environment-visitor": "^7.24.7",
-        "@babel/helper-member-expression-to-functions": "^7.24.7",
-        "@babel/helper-optimise-call-expression": "^7.24.7"
+        "@babel/helper-member-expression-to-functions": "^7.24.8",
+        "@babel/helper-optimise-call-expression": "^7.24.7",
+        "@babel/traverse": "^7.25.0"
       }
     },
     "@babel/helper-simple-access": {
@@ -330,14 +302,6 @@
         "@babel/types": "^7.24.7"
       }
     },
-    "@babel/helper-split-export-declaration": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.7.tgz",
-      "integrity": "sha512-oy5V7pD+UvfkEATUKvIjvIAH/xCzfsFVw7ygW2SI6NClZzquT+mwdTfgfdbUiceh6iQO0CHtCPsyze/MZ2YbAA==",
-      "requires": {
-        "@babel/types": "^7.24.7"
-      }
-    },
     "@babel/helper-string-parser": {
       "version": "7.24.8",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.8.tgz",
@@ -354,23 +318,22 @@
       "integrity": "sha512-xb8t9tD1MHLungh/AIoWYN+gVHaB9kwlu8gffXGSt3FFEIT7RjS+xWbc2vUD1UTZdIpKj/ab3rdqJ7ufngyi2Q=="
     },
     "@babel/helper-wrap-function": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.24.7.tgz",
-      "integrity": "sha512-N9JIYk3TD+1vq/wn77YnJOqMtfWhNewNE+DJV4puD2X7Ew9J4JvrzrFDfTfyv5EgEXVy9/Wt8QiOErzEmv5Ifw==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.25.0.tgz",
+      "integrity": "sha512-s6Q1ebqutSiZnEjaofc/UKDyC4SbzV5n5SrA2Gq8UawLycr3i04f1dX4OzoQVnexm6aOCh37SQNYlJ/8Ku+PMQ==",
       "requires": {
-        "@babel/helper-function-name": "^7.24.7",
-        "@babel/template": "^7.24.7",
-        "@babel/traverse": "^7.24.7",
-        "@babel/types": "^7.24.7"
+        "@babel/template": "^7.25.0",
+        "@babel/traverse": "^7.25.0",
+        "@babel/types": "^7.25.0"
       }
     },
     "@babel/helpers": {
-      "version": "7.24.8",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.8.tgz",
-      "integrity": "sha512-gV2265Nkcz7weJJfvDoAEVzC1e2OTDpkGbEsebse8koXUJUXPsCMi7sRo/+SPMuMZ9MtUPnGwITTnQnU5YjyaQ==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.25.0.tgz",
+      "integrity": "sha512-MjgLZ42aCm0oGjJj8CtSM3DB8NOOf8h2l7DCTePJs29u+v7yO/RBX9nShlKMgFnRks/Q4tBAe7Hxnov9VkGwLw==",
       "requires": {
-        "@babel/template": "^7.24.7",
-        "@babel/types": "^7.24.8"
+        "@babel/template": "^7.25.0",
+        "@babel/types": "^7.25.0"
       }
     },
     "@babel/highlight": {
@@ -385,25 +348,33 @@
       }
     },
     "@babel/parser": {
-      "version": "7.24.8",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.8.tgz",
-      "integrity": "sha512-WzfbgXOkGzZiXXCqk43kKwZjzwx4oulxZi3nq2TYL9mOjQv6kYwul9mz6ID36njuL7Xkp6nJEfok848Zj10j/w=="
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.0.tgz",
+      "integrity": "sha512-CzdIU9jdP0dg7HdyB+bHvDJGagUv+qtzZt5rYCWwW6tITNqV9odjp6Qu41gkG0ca5UfdDUWrKkiAnHHdGRnOrA=="
     },
     "@babel/plugin-bugfix-firefox-class-in-computed-class-key": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.24.7.tgz",
-      "integrity": "sha512-TiT1ss81W80eQsN+722OaeQMY/G4yTb4G9JrqeiDADs3N8lbPMGldWi9x8tyqCW5NLx1Jh2AvkE6r6QvEltMMQ==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.25.0.tgz",
+      "integrity": "sha512-dG0aApncVQwAUJa8tP1VHTnmU67BeIQvKafd3raEx315H54FfkZSz3B/TT+33ZQAjatGJA79gZqTtqL5QZUKXw==",
       "requires": {
-        "@babel/helper-environment-visitor": "^7.24.7",
-        "@babel/helper-plugin-utils": "^7.24.7"
+        "@babel/helper-plugin-utils": "^7.24.8",
+        "@babel/traverse": "^7.25.0"
+      }
+    },
+    "@babel/plugin-bugfix-safari-class-field-initializer-scope": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-7.25.0.tgz",
+      "integrity": "sha512-Bm4bH2qsX880b/3ziJ8KD711LT7z4u8CFudmjqle65AZj/HNUFhEf90dqYv6O86buWvSBmeQDjv0Tn2aF/bIBA==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.24.8"
       }
     },
     "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.24.7.tgz",
-      "integrity": "sha512-unaQgZ/iRu/By6tsjMZzpeBZjChYfLYry6HrEXPoz3KmfF0sVBQ1l8zKMQ4xRGLWVsjuvB8nQfjNP/DcfEOCsg==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.25.0.tgz",
+      "integrity": "sha512-lXwdNZtTmeVOOFtwM/WDe7yg1PL8sYhRk/XH0FzbR2HDQ0xC+EnQ/JHeoMYSavtU115tnUk0q9CDyq8si+LMAA==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.24.7"
+        "@babel/helper-plugin-utils": "^7.24.8"
       }
     },
     "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
@@ -417,12 +388,12 @@
       }
     },
     "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.24.7.tgz",
-      "integrity": "sha512-utA4HuR6F4Vvcr+o4DnjL8fCOlgRFGbeeBEGNg3ZTrLFw6VWG5XmUrvcQ0FjIYMU2ST4XcR2Wsp7t9qOAPnxMg==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.25.0.tgz",
+      "integrity": "sha512-tggFrk1AIShG/RUQbEwt2Tr/E+ObkfwrPjR6BjbRvsx24+PSjK8zrq0GWPNCjo8qpRx4DuJzlcvWJqlm+0h3kw==",
       "requires": {
-        "@babel/helper-environment-visitor": "^7.24.7",
-        "@babel/helper-plugin-utils": "^7.24.7"
+        "@babel/helper-plugin-utils": "^7.24.8",
+        "@babel/traverse": "^7.25.0"
       }
     },
     "@babel/plugin-proposal-class-properties": {
@@ -680,14 +651,14 @@
       }
     },
     "@babel/plugin-transform-async-generator-functions": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.24.7.tgz",
-      "integrity": "sha512-o+iF77e3u7ZS4AoAuJvapz9Fm001PuD2V3Lp6OSE4FYQke+cSewYtnek+THqGRWyQloRCyvWL1OkyfNEl9vr/g==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.25.0.tgz",
+      "integrity": "sha512-uaIi2FdqzjpAMvVqvB51S42oC2JEVgh0LDsGfZVDysWE8LrJtQC2jvKmOqEYThKyB7bDEb7BP1GYWDm7tABA0Q==",
       "requires": {
-        "@babel/helper-environment-visitor": "^7.24.7",
-        "@babel/helper-plugin-utils": "^7.24.7",
-        "@babel/helper-remap-async-to-generator": "^7.24.7",
-        "@babel/plugin-syntax-async-generators": "^7.8.4"
+        "@babel/helper-plugin-utils": "^7.24.8",
+        "@babel/helper-remap-async-to-generator": "^7.25.0",
+        "@babel/plugin-syntax-async-generators": "^7.8.4",
+        "@babel/traverse": "^7.25.0"
       }
     },
     "@babel/plugin-transform-async-to-generator": {
@@ -709,11 +680,11 @@
       }
     },
     "@babel/plugin-transform-block-scoping": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.24.7.tgz",
-      "integrity": "sha512-Nd5CvgMbWc+oWzBsuaMcbwjJWAcp5qzrbg69SZdHSP7AMY0AbWFqFO0WTFCA1jxhMCwodRwvRec8k0QUbZk7RQ==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.25.0.tgz",
+      "integrity": "sha512-yBQjYoOjXlFv9nlXb3f1casSHOZkWr29NX+zChVanLg5Nc157CrbEX9D7hxxtTpuFy7Q0YzmmWfJxzvps4kXrQ==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.24.7"
+        "@babel/helper-plugin-utils": "^7.24.8"
       }
     },
     "@babel/plugin-transform-class-properties": {
@@ -736,17 +707,15 @@
       }
     },
     "@babel/plugin-transform-classes": {
-      "version": "7.24.8",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.24.8.tgz",
-      "integrity": "sha512-VXy91c47uujj758ud9wx+OMgheXm4qJfyhj1P18YvlrQkNOSrwsteHk+EFS3OMGfhMhpZa0A+81eE7G4QC+3CA==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.25.0.tgz",
+      "integrity": "sha512-xyi6qjr/fYU304fiRwFbekzkqVJZ6A7hOjWZd+89FVcBqPV3S9Wuozz82xdpLspckeaafntbzglaW4pqpzvtSw==",
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.24.7",
         "@babel/helper-compilation-targets": "^7.24.8",
-        "@babel/helper-environment-visitor": "^7.24.7",
-        "@babel/helper-function-name": "^7.24.7",
         "@babel/helper-plugin-utils": "^7.24.8",
-        "@babel/helper-replace-supers": "^7.24.7",
-        "@babel/helper-split-export-declaration": "^7.24.7",
+        "@babel/helper-replace-supers": "^7.25.0",
+        "@babel/traverse": "^7.25.0",
         "globals": "^11.1.0"
       }
     },
@@ -782,6 +751,15 @@
       "integrity": "sha512-JdYfXyCRihAe46jUIliuL2/s0x0wObgwwiGxw/UbgJBr20gQBThrokO4nYKgWkD7uBaqM7+9x5TU7NkExZJyzw==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.24.7"
+      }
+    },
+    "@babel/plugin-transform-duplicate-named-capturing-groups-regex": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.25.0.tgz",
+      "integrity": "sha512-YLpb4LlYSc3sCUa35un84poXoraOiQucUTTu8X1j18JV+gNa8E0nyUf/CjZ171IRGr4jEguF+vzJU66QZhn29g==",
+      "requires": {
+        "@babel/helper-create-regexp-features-plugin": "^7.25.0",
+        "@babel/helper-plugin-utils": "^7.24.8"
       }
     },
     "@babel/plugin-transform-dynamic-import": {
@@ -830,13 +808,13 @@
       }
     },
     "@babel/plugin-transform-function-name": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.24.7.tgz",
-      "integrity": "sha512-U9FcnA821YoILngSmYkW6FjyQe2TyZD5pHt4EVIhmcTkrJw/3KqcrRSxuOo5tFZJi7TE19iDyI1u+weTI7bn2w==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.25.0.tgz",
+      "integrity": "sha512-CQmfSnK14eYu82fu6GlCwRciHB7mp7oLN+DeyGDDwUr9cMwuSVviJKPXw/YcRYZdB1TdlLJWHHwXwnwD1WnCmQ==",
       "requires": {
-        "@babel/helper-compilation-targets": "^7.24.7",
-        "@babel/helper-function-name": "^7.24.7",
-        "@babel/helper-plugin-utils": "^7.24.7"
+        "@babel/helper-compilation-targets": "^7.24.8",
+        "@babel/helper-plugin-utils": "^7.24.8",
+        "@babel/traverse": "^7.25.0"
       }
     },
     "@babel/plugin-transform-json-strings": {
@@ -893,14 +871,14 @@
       }
     },
     "@babel/plugin-transform-modules-systemjs": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.24.7.tgz",
-      "integrity": "sha512-GYQE0tW7YoaN13qFh3O1NCY4MPkUiAH3fiF7UcV/I3ajmDKEdG3l+UOcbAm4zUE3gnvUU+Eni7XrVKo9eO9auw==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.25.0.tgz",
+      "integrity": "sha512-YPJfjQPDXxyQWg/0+jHKj1llnY5f/R6a0p/vP4lPymxLu7Lvl4k2WMitqi08yxwQcCVUUdG9LCUj4TNEgAp3Jw==",
       "requires": {
-        "@babel/helper-hoist-variables": "^7.24.7",
-        "@babel/helper-module-transforms": "^7.24.7",
-        "@babel/helper-plugin-utils": "^7.24.7",
-        "@babel/helper-validator-identifier": "^7.24.7"
+        "@babel/helper-module-transforms": "^7.25.0",
+        "@babel/helper-plugin-utils": "^7.24.8",
+        "@babel/helper-validator-identifier": "^7.24.7",
+        "@babel/traverse": "^7.25.0"
       }
     },
     "@babel/plugin-transform-modules-umd": {
@@ -1146,13 +1124,14 @@
       }
     },
     "@babel/plugin-transform-typescript": {
-      "version": "7.24.8",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.24.8.tgz",
-      "integrity": "sha512-CgFgtN61BbdOGCP4fLaAMOPkzWUh6yQZNMr5YSt8uz2cZSSiQONCQFWqsE4NeVfOIhqDOlS9CR3WD91FzMeB2Q==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.25.0.tgz",
+      "integrity": "sha512-LZicxFzHIw+Sa3pzgMgSz6gdpsdkfiMObHUzhSIrwKF0+/rP/nuR49u79pSS+zIFJ1FeGeqQD2Dq4QGFbOVvSw==",
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.24.7",
-        "@babel/helper-create-class-features-plugin": "^7.24.8",
+        "@babel/helper-create-class-features-plugin": "^7.25.0",
         "@babel/helper-plugin-utils": "^7.24.8",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.24.7",
         "@babel/plugin-syntax-typescript": "^7.24.7"
       }
     },
@@ -1192,18 +1171,19 @@
       }
     },
     "@babel/preset-env": {
-      "version": "7.24.8",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.24.8.tgz",
-      "integrity": "sha512-vObvMZB6hNWuDxhSaEPTKCwcqkAIuDtE+bQGn4XMXne1DSLzFVY8Vmj1bm+mUQXYNN8NmaQEO+r8MMbzPr1jBQ==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.25.0.tgz",
+      "integrity": "sha512-vYAA8PrCOeZfG4D87hmw1KJ1BPubghXP1e2MacRFwECGNKL76dkA38JEwYllbvQCpf/kLxsTtir0b8MtxKoVCw==",
       "requires": {
-        "@babel/compat-data": "^7.24.8",
+        "@babel/compat-data": "^7.25.0",
         "@babel/helper-compilation-targets": "^7.24.8",
         "@babel/helper-plugin-utils": "^7.24.8",
         "@babel/helper-validator-option": "^7.24.8",
-        "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.24.7",
-        "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.24.7",
+        "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.25.0",
+        "@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.25.0",
+        "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.25.0",
         "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.24.7",
-        "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.24.7",
+        "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.25.0",
         "@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
         "@babel/plugin-syntax-async-generators": "^7.8.4",
         "@babel/plugin-syntax-class-properties": "^7.12.13",
@@ -1224,29 +1204,30 @@
         "@babel/plugin-syntax-top-level-await": "^7.14.5",
         "@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
         "@babel/plugin-transform-arrow-functions": "^7.24.7",
-        "@babel/plugin-transform-async-generator-functions": "^7.24.7",
+        "@babel/plugin-transform-async-generator-functions": "^7.25.0",
         "@babel/plugin-transform-async-to-generator": "^7.24.7",
         "@babel/plugin-transform-block-scoped-functions": "^7.24.7",
-        "@babel/plugin-transform-block-scoping": "^7.24.7",
+        "@babel/plugin-transform-block-scoping": "^7.25.0",
         "@babel/plugin-transform-class-properties": "^7.24.7",
         "@babel/plugin-transform-class-static-block": "^7.24.7",
-        "@babel/plugin-transform-classes": "^7.24.8",
+        "@babel/plugin-transform-classes": "^7.25.0",
         "@babel/plugin-transform-computed-properties": "^7.24.7",
         "@babel/plugin-transform-destructuring": "^7.24.8",
         "@babel/plugin-transform-dotall-regex": "^7.24.7",
         "@babel/plugin-transform-duplicate-keys": "^7.24.7",
+        "@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.25.0",
         "@babel/plugin-transform-dynamic-import": "^7.24.7",
         "@babel/plugin-transform-exponentiation-operator": "^7.24.7",
         "@babel/plugin-transform-export-namespace-from": "^7.24.7",
         "@babel/plugin-transform-for-of": "^7.24.7",
-        "@babel/plugin-transform-function-name": "^7.24.7",
+        "@babel/plugin-transform-function-name": "^7.25.0",
         "@babel/plugin-transform-json-strings": "^7.24.7",
         "@babel/plugin-transform-literals": "^7.24.7",
         "@babel/plugin-transform-logical-assignment-operators": "^7.24.7",
         "@babel/plugin-transform-member-expression-literals": "^7.24.7",
         "@babel/plugin-transform-modules-amd": "^7.24.7",
         "@babel/plugin-transform-modules-commonjs": "^7.24.8",
-        "@babel/plugin-transform-modules-systemjs": "^7.24.7",
+        "@babel/plugin-transform-modules-systemjs": "^7.25.0",
         "@babel/plugin-transform-modules-umd": "^7.24.7",
         "@babel/plugin-transform-named-capturing-groups-regex": "^7.24.7",
         "@babel/plugin-transform-new-target": "^7.24.7",
@@ -1327,44 +1308,41 @@
       "integrity": "sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA=="
     },
     "@babel/runtime": {
-      "version": "7.24.8",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.8.tgz",
-      "integrity": "sha512-5F7SDGs1T72ZczbRwbGO9lQi0NLjQxzl6i4lJxLxfW9U5UluCSyEJeniWvnhl3/euNiqQVbo8zruhsDfid0esA==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.0.tgz",
+      "integrity": "sha512-7dRy4DwXwtzBrPbZflqxnvfxLF8kdZXPkhymtDeFoFqE6ldzjQFgYTtYIFARcLEYDrqfBfYcZt1WqFxRoyC9Rw==",
       "requires": {
         "regenerator-runtime": "^0.14.0"
       }
     },
     "@babel/template": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.7.tgz",
-      "integrity": "sha512-jYqfPrU9JTF0PmPy1tLYHW4Mp4KlgxJD9l2nP9fD6yT/ICi554DmrWBAEYpIelzjHf1msDP3PxJIRt/nFNfBig==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.0.tgz",
+      "integrity": "sha512-aOOgh1/5XzKvg1jvVz7AVrx2piJ2XBi227DHmbY6y+bM9H2FlN+IfecYu4Xl0cNiiVejlsCri89LUsbj8vJD9Q==",
       "requires": {
         "@babel/code-frame": "^7.24.7",
-        "@babel/parser": "^7.24.7",
-        "@babel/types": "^7.24.7"
+        "@babel/parser": "^7.25.0",
+        "@babel/types": "^7.25.0"
       }
     },
     "@babel/traverse": {
-      "version": "7.24.8",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.8.tgz",
-      "integrity": "sha512-t0P1xxAPzEDcEPmjprAQq19NWum4K0EQPjMwZQZbHt+GiZqvjCHjj755Weq1YRPVzBI+3zSfvScfpnuIecVFJQ==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.0.tgz",
+      "integrity": "sha512-ubALThHQy4GCf6mbb+5ZRNmLLCI7bJ3f8Q6LHBSRlSKSWj5a7dSUzJBLv3VuIhFrFPgjF4IzPF567YG/HSCdZA==",
       "requires": {
         "@babel/code-frame": "^7.24.7",
-        "@babel/generator": "^7.24.8",
-        "@babel/helper-environment-visitor": "^7.24.7",
-        "@babel/helper-function-name": "^7.24.7",
-        "@babel/helper-hoist-variables": "^7.24.7",
-        "@babel/helper-split-export-declaration": "^7.24.7",
-        "@babel/parser": "^7.24.8",
-        "@babel/types": "^7.24.8",
+        "@babel/generator": "^7.25.0",
+        "@babel/parser": "^7.25.0",
+        "@babel/template": "^7.25.0",
+        "@babel/types": "^7.25.0",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       }
     },
     "@babel/types": {
-      "version": "7.24.9",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.9.tgz",
-      "integrity": "sha512-xm8XrMKz0IlUdocVbYJe0Z9xEgidU7msskG8BbhnTPK/HZ2z/7FP7ykqPgrUH+C+r414mNfNWam1f2vqOjqjYQ==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.0.tgz",
+      "integrity": "sha512-LcnxQSsd9aXOIgmmSpvZ/1yo46ra2ESYyqLcryaBZOghxy5qqOBjvCWP5JfkI8yl9rlxRgdLTTMCQQRcN2hdCg==",
       "requires": {
         "@babel/helper-string-parser": "^7.24.8",
         "@babel/helper-validator-identifier": "^7.24.7",
@@ -12112,7 +12090,7 @@
       }
     },
     "pcic-react-leaflet-components": {
-      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#cbf547c6e15411b881bd6684426e9280671fc678",
+      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#70bba72eda6522b3eee758ff3821ae52ddeb1585",
       "from": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#add-BCVectorBaseMap",
       "requires": {
         "@testing-library/jest-dom": "^5.16.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12096,7 +12096,7 @@
       }
     },
     "pcic-react-leaflet-components": {
-      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#98f6efe90fabfa26e5377acce788a2770217e59d",
+      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#1e2b49f3ac02448f1d91344ef46ff466d52647a7",
       "from": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#add-BCVectorBaseMap",
       "requires": {
         "@testing-library/jest-dom": "^5.16.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12096,7 +12096,7 @@
       }
     },
     "pcic-react-leaflet-components": {
-      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#15bb605b419d4c3a3876ca6b0b3563e58bdca858",
+      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#b005f069d8c0cf1896f02940b3955d13af66485d",
       "from": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#add-BCVectorBaseMap",
       "requires": {
         "@testing-library/jest-dom": "^5.16.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12096,7 +12096,7 @@
       }
     },
     "pcic-react-leaflet-components": {
-      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#bca6ab47da1a3161373a2ad083b377ff231dec9a",
+      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#d8fbfcfb66daea14fdef00ff44ff8b44a0a8688b",
       "from": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#add-BCVectorBaseMap",
       "requires": {
         "@testing-library/jest-dom": "^5.16.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6122,9 +6122,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.1.tgz",
-      "integrity": "sha512-FKbOCOQ5QRB3VlIbl1LZQefWIYwszlBloaXcY2rbfpu9ioJnNh3TK03YtIDKDo3WKBi8u+YV4+Fn2CkEozgf4w=="
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.2.tgz",
+      "integrity": "sha512-kc4r3U3V3WLaaZqThjYz/Y6z8tJe+7K0bbjUVo3i+LWIypVdMx5nXCkwRe6SWbY6ILqLdc1rKcKmr3HoH7wjSQ=="
     },
     "emittery": {
       "version": "0.8.1",
@@ -12112,7 +12112,7 @@
       }
     },
     "pcic-react-leaflet-components": {
-      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#7d1303137a561da35f99786b110e54c0dfd9aeef",
+      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#cbf547c6e15411b881bd6684426e9280671fc678",
       "from": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#add-BCVectorBaseMap",
       "requires": {
         "@testing-library/jest-dom": "^5.16.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12096,7 +12096,7 @@
       }
     },
     "pcic-react-leaflet-components": {
-      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#fd78f743bc5577263e9af38b3474f741facee10e",
+      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#153a838dfd06fdb036a7d617c01ea7b8cc2c010b",
       "from": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#add-BCVectorBaseMap",
       "requires": {
         "@testing-library/jest-dom": "^5.16.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12096,7 +12096,7 @@
       }
     },
     "pcic-react-leaflet-components": {
-      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#f3ba95afe605c6cbe777de3e6916097039b21ee0",
+      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#bca6ab47da1a3161373a2ad083b377ff231dec9a",
       "from": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#add-BCVectorBaseMap",
       "requires": {
         "@testing-library/jest-dom": "^5.16.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12093,7 +12093,7 @@
       }
     },
     "pcic-react-leaflet-components": {
-      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#e860436643123f550a1d8d4128e59d6a5a5cd31d",
+      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#dd25faac9765537aa959c9dc419d587cd71d3183",
       "from": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#add-BCVectorBaseMap",
       "requires": {
         "@testing-library/jest-dom": "^5.16.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12096,7 +12096,7 @@
       }
     },
     "pcic-react-leaflet-components": {
-      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#1e2b49f3ac02448f1d91344ef46ff466d52647a7",
+      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#9d65ab22491ddf58d724b99f37ed4c5233c593bd",
       "from": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#add-BCVectorBaseMap",
       "requires": {
         "@testing-library/jest-dom": "^5.16.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12096,7 +12096,7 @@
       }
     },
     "pcic-react-leaflet-components": {
-      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#011fb444a61be1de3afa9ca1a4372699fec28fb1",
+      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#c8accb193f7523f0af9938e03268a2b50f904d91",
       "from": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#add-BCVectorBaseMap",
       "requires": {
         "@testing-library/jest-dom": "^5.16.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8053,9 +8053,9 @@
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA=="
     },
     "is-core-module": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.0.tgz",
-      "integrity": "sha512-Dd+Lb2/zvk9SKy1TGCt1wFJFo/MWBPMX5x7KcvLajWTGuomczdQX61PvY5yK6SVACwpoexWo81IfFyoKY2QnTA==",
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
+      "integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
       "requires": {
         "hasown": "^2.0.2"
       }
@@ -12096,7 +12096,7 @@
       }
     },
     "pcic-react-leaflet-components": {
-      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#c8accb193f7523f0af9938e03268a2b50f904d91",
+      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#77d99e4010ba68c89156999853f74874f646e45d",
       "from": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#add-BCVectorBaseMap",
       "requires": {
         "@testing-library/jest-dom": "^5.16.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12093,7 +12093,7 @@
       }
     },
     "pcic-react-leaflet-components": {
-      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#bdec5b2a1fe5a86599ef89e5d1e4292bacc385b2",
+      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#b8c0216f35a84c1c2e92cf9fd0be65b8dad5ca62",
       "from": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#add-BCVectorBaseMap",
       "requires": {
         "@testing-library/jest-dom": "^5.16.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3525,9 +3525,9 @@
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w=="
     },
     "@types/node": {
-      "version": "22.4.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.4.1.tgz",
-      "integrity": "sha512-1tbpb9325+gPnKK0dMm+/LMriX0vKxf6RnB0SZUqfyVkQ4fMgUSySqhxE/y8Jvs4NyF1yHzTfG9KlnkIODxPKg==",
+      "version": "22.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.0.tgz",
+      "integrity": "sha512-DkFrJOe+rfdHTqqMg0bSNlGlQ85hSoh2TPzZyhHsXnMtligRWpxUySiyw8FY14ITt24HVCiQPWxS3KO/QlGmWg==",
       "requires": {
         "undici-types": "~6.19.2"
       }
@@ -6106,9 +6106,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.5.12",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.12.tgz",
-      "integrity": "sha512-tIhPkdlEoCL1Y+PToq3zRNehUaKp3wBX/sr7aclAWdIWjvqAe/Im/H0SiCM4c1Q8BLPHCdoJTol+ZblflydehA=="
+      "version": "1.5.13",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.13.tgz",
+      "integrity": "sha512-lbBcvtIJ4J6sS4tb5TLp1b4LyfCdMkwStzXPyAgVgTRAsep4bvrAGaBOP7ZJtQMNJpSQ9SqG4brWOroNaQtm7Q=="
     },
     "emittery": {
       "version": "0.8.1",
@@ -12096,7 +12096,7 @@
       }
     },
     "pcic-react-leaflet-components": {
-      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#de53fb91862e1127fa51b70dd113ab272c05c2c7",
+      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#03af1b293fac0b7cf51a0d6b78e09a3c3826f1c8",
       "from": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#add-BCVectorBaseMap",
       "requires": {
         "@testing-library/jest-dom": "^5.16.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12093,7 +12093,7 @@
       }
     },
     "pcic-react-leaflet-components": {
-      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#392aca4844c554496792ff3d39408eea592eb8cd",
+      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#f1f9273a8a2765d68c9b4f193ed38809912a959b",
       "from": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#add-BCVectorBaseMap",
       "requires": {
         "@testing-library/jest-dom": "^5.16.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12093,7 +12093,7 @@
       }
     },
     "pcic-react-leaflet-components": {
-      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#48e3c8420a3cea19bd5ff0310680cf75e0b9f8dc",
+      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#f54bc17750b2459bfefb25179f8019e2c562e493",
       "from": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#add-BCVectorBaseMap",
       "requires": {
         "@testing-library/jest-dom": "^5.16.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3525,9 +3525,9 @@
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w=="
     },
     "@types/node": {
-      "version": "22.1.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.1.0.tgz",
-      "integrity": "sha512-AOmuRF0R2/5j1knA3c6G3HOk523Ga+l+ZXltX8SF1+5oqcXijjfTd8fY3XRZqSihEu9XhtQnKYLmkFaoxgsJHw==",
+      "version": "22.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.2.0.tgz",
+      "integrity": "sha512-bm6EG6/pCpkxDf/0gDNDdtDILMOHgaQBVOJGdwsqClnxA3xL6jtMv76rLBc006RVMWbmaf0xbmom4Z/5o2nRkQ==",
       "requires": {
         "undici-types": "~6.13.0"
       }
@@ -12093,7 +12093,7 @@
       }
     },
     "pcic-react-leaflet-components": {
-      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#4876b80d1da7db1b73c707d751c29404f92894ca",
+      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#48e3c8420a3cea19bd5ff0310680cf75e0b9f8dc",
       "from": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#add-BCVectorBaseMap",
       "requires": {
         "@testing-library/jest-dom": "^5.16.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12093,7 +12093,7 @@
       }
     },
     "pcic-react-leaflet-components": {
-      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#e08b28a41d3c81665f73269ca08f0a20993d1496",
+      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#3ea1feaccc54a771ef777e4a17a0c8487deef8df",
       "from": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#add-BCVectorBaseMap",
       "requires": {
         "@testing-library/jest-dom": "^5.16.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12096,7 +12096,7 @@
       }
     },
     "pcic-react-leaflet-components": {
-      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#0ef9ca5e46d2eac783bdd7e841b0f3fcfd75bc3a",
+      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#2aa47a556dcf2641ddf3b73189eae69c292237f3",
       "from": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#add-BCVectorBaseMap",
       "requires": {
         "@testing-library/jest-dom": "^5.16.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12096,7 +12096,7 @@
       }
     },
     "pcic-react-leaflet-components": {
-      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#d8fbfcfb66daea14fdef00ff44ff8b44a0a8688b",
+      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#4dc65c34143185e08de7882cc4d045e334cd16b4",
       "from": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#add-BCVectorBaseMap",
       "requires": {
         "@testing-library/jest-dom": "^5.16.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -348,17 +348,20 @@
       }
     },
     "@babel/parser": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.0.tgz",
-      "integrity": "sha512-CzdIU9jdP0dg7HdyB+bHvDJGagUv+qtzZt5rYCWwW6tITNqV9odjp6Qu41gkG0ca5UfdDUWrKkiAnHHdGRnOrA=="
+      "version": "7.25.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.3.tgz",
+      "integrity": "sha512-iLTJKDbJ4hMvFPgQwwsVoxtHyWpKKPBrxkANrSYewDPaPpT5py5yeVkgPIJ7XYXhndxJpaA3PyALSXQ7u8e/Dw==",
+      "requires": {
+        "@babel/types": "^7.25.2"
+      }
     },
     "@babel/plugin-bugfix-firefox-class-in-computed-class-key": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.25.0.tgz",
-      "integrity": "sha512-dG0aApncVQwAUJa8tP1VHTnmU67BeIQvKafd3raEx315H54FfkZSz3B/TT+33ZQAjatGJA79gZqTtqL5QZUKXw==",
+      "version": "7.25.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.25.3.tgz",
+      "integrity": "sha512-wUrcsxZg6rqBXG05HG1FPYgsP6EvwF4WpBbxIpWIIYnH8wG0gzx3yZY3dtEHas4sTAOGkbTsc9EGPxwff8lRoA==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.24.8",
-        "@babel/traverse": "^7.25.0"
+        "@babel/traverse": "^7.25.3"
       }
     },
     "@babel/plugin-bugfix-safari-class-field-initializer-scope": {
@@ -1171,15 +1174,15 @@
       }
     },
     "@babel/preset-env": {
-      "version": "7.25.2",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.25.2.tgz",
-      "integrity": "sha512-Y2Vkwy3ITW4id9c6KXshVV/x5yCGK7VdJmKkzOzNsDZMojRKfSA/033rRbLqlRozmhRXCejxWHLSJOg/wUHfzw==",
+      "version": "7.25.3",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.25.3.tgz",
+      "integrity": "sha512-QsYW7UeAaXvLPX9tdVliMJE7MD7M6MLYVTovRTIwhoYQVFHR1rM4wO8wqAezYi3/BpSD+NzVCZ69R6smWiIi8g==",
       "requires": {
         "@babel/compat-data": "^7.25.2",
         "@babel/helper-compilation-targets": "^7.25.2",
         "@babel/helper-plugin-utils": "^7.24.8",
         "@babel/helper-validator-option": "^7.24.8",
-        "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.25.0",
+        "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.25.3",
         "@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.25.0",
         "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.25.0",
         "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.24.7",
@@ -1326,13 +1329,13 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.25.2",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.2.tgz",
-      "integrity": "sha512-s4/r+a7xTnny2O6FcZzqgT6nE4/GHEdcqj4qAeglbUOh0TeglEfmNJFAd/OLoVtGd6ZhAO8GCVvCNUO5t/VJVQ==",
+      "version": "7.25.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.3.tgz",
+      "integrity": "sha512-HefgyP1x754oGCsKmV5reSmtV7IXj/kpaE1XYY+D9G5PvKKoFfSbiS4M77MdjuwlZKDIKFCffq9rPU+H/s3ZdQ==",
       "requires": {
         "@babel/code-frame": "^7.24.7",
         "@babel/generator": "^7.25.0",
-        "@babel/parser": "^7.25.0",
+        "@babel/parser": "^7.25.3",
         "@babel/template": "^7.25.0",
         "@babel/types": "^7.25.2",
         "debug": "^4.3.1",
@@ -3464,9 +3467,9 @@
       "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA=="
     },
     "@types/http-proxy": {
-      "version": "1.17.14",
-      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.14.tgz",
-      "integrity": "sha512-SSrD0c1OQzlFX7pGu1eXxSEjemej64aaNPRhhVYUGqXh0BtldAAx37MG8btcumvpgKyZp1F5Gn3JkktdxiFv6w==",
+      "version": "1.17.15",
+      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.15.tgz",
+      "integrity": "sha512-25g5atgiVNTIv0LBDTg1H74Hvayx0ajtJPLLcYE3whFv75J0pWNtOBzaXJQgDTmrX1bx5U9YC2w/n65BN1HwRQ==",
       "requires": {
         "@types/node": "*"
       }
@@ -3522,11 +3525,11 @@
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w=="
     },
     "@types/node": {
-      "version": "22.0.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.0.0.tgz",
-      "integrity": "sha512-VT7KSYudcPOzP5Q0wfbowyNLaVR8QWUdw+088uFWwfvpY6uCWaXpqV6ieLAu9WBcnTa7H4Z5RLK8I5t2FuOcqw==",
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.1.0.tgz",
+      "integrity": "sha512-AOmuRF0R2/5j1knA3c6G3HOk523Ga+l+ZXltX8SF1+5oqcXijjfTd8fY3XRZqSihEu9XhtQnKYLmkFaoxgsJHw==",
       "requires": {
-        "undici-types": "~6.11.1"
+        "undici-types": "~6.13.0"
       }
     },
     "@types/node-forge": {
@@ -3684,9 +3687,9 @@
       }
     },
     "@types/yargs": {
-      "version": "17.0.32",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
-      "integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
+      "version": "17.0.33",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
+      "integrity": "sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==",
       "requires": {
         "@types/yargs-parser": "*"
       }
@@ -4279,15 +4282,15 @@
       "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
     },
     "autoprefixer": {
-      "version": "10.4.19",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.19.tgz",
-      "integrity": "sha512-BaENR2+zBZ8xXhM4pUaKUxlVdxZ0EZhjvbopwnXmxRUfqDmwSpC2lAi/QXvx7NRdPCo1WKEcEF6mV64si1z4Ew==",
+      "version": "10.4.20",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.20.tgz",
+      "integrity": "sha512-XY25y5xSv/wEoqzDyXXME4AFfkZI0P23z6Fs3YgymDnKJkCGOnkL0iTxCa85UTqaSgfcqyf3UA6+c7wUvx/16g==",
       "requires": {
-        "browserslist": "^4.23.0",
-        "caniuse-lite": "^1.0.30001599",
+        "browserslist": "^4.23.3",
+        "caniuse-lite": "^1.0.30001646",
         "fraction.js": "^4.3.7",
         "normalize-range": "^0.1.2",
-        "picocolors": "^1.0.0",
+        "picocolors": "^1.0.1",
         "postcss-value-parser": "^4.2.0"
       }
     },
@@ -4535,12 +4538,12 @@
       }
     },
     "babel-plugin-polyfill-corejs3": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.10.4.tgz",
-      "integrity": "sha512-25J6I8NGfa5YkCDogHRID3fVCadIR8/pGl1/spvCkzb6lVn6SR3ojpx9nOn9iEBcUsjY24AmdKm5khcfKdylcg==",
+      "version": "0.10.6",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.10.6.tgz",
+      "integrity": "sha512-b37+KR2i/khY5sKmWNVQAnitvquQbNdWy6lJdsr0kmquCKEEUgMKK4SboVM3HtfnZilfjr4MMQ7vY58FVWDtIA==",
       "requires": {
-        "@babel/helper-define-polyfill-provider": "^0.6.1",
-        "core-js-compat": "^3.36.1"
+        "@babel/helper-define-polyfill-provider": "^0.6.2",
+        "core-js-compat": "^3.38.0"
       }
     },
     "babel-plugin-polyfill-regenerator": {
@@ -4752,13 +4755,13 @@
       "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow=="
     },
     "browserslist": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.2.tgz",
-      "integrity": "sha512-qkqSyistMYdxAcw+CzbZwlBy8AGmS/eEWs+sEV5TnLRGDOL+C5M2EnH6tlZyg0YoAxGJAFKh61En9BR941GnHA==",
+      "version": "4.23.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.3.tgz",
+      "integrity": "sha512-btwCFJVjI4YWDNfau8RhZ+B1Q/VLoUITrm3RlP6y1tYGWIOa+InuYiRGXUBXo8nA1qKmHMyLB/iVQg5TT4eFoA==",
       "requires": {
-        "caniuse-lite": "^1.0.30001640",
-        "electron-to-chromium": "^1.4.820",
-        "node-releases": "^2.0.14",
+        "caniuse-lite": "^1.0.30001646",
+        "electron-to-chromium": "^1.5.4",
+        "node-releases": "^2.0.18",
         "update-browserslist-db": "^1.1.0"
       }
     },
@@ -4857,9 +4860,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001644",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001644.tgz",
-      "integrity": "sha512-YGvlOZB4QhZuiis+ETS0VXR+MExbFf4fZYYeMTEE0aTQd/RdIjkTyZjLrbYVKnHzppDvnOhritRVv+i7Go6mHw=="
+      "version": "1.0.30001650",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001650.tgz",
+      "integrity": "sha512-fgEc7hP/LB7iicdXHUI9VsBsMZmUmlVJeQP2qqQW+3lkqVhbmjEU8zp+h5stWeilX+G7uXuIUIIlWlDw9jdt8g=="
     },
     "case-sensitive-paths-webpack-plugin": {
       "version": "2.4.0",
@@ -5138,22 +5141,22 @@
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
     },
     "core-js": {
-      "version": "3.37.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.37.1.tgz",
-      "integrity": "sha512-Xn6qmxrQZyB0FFY8E3bgRXei3lWDJHhvI+u0q9TKIYM49G8pAr0FgnnrFRAmsbptZL1yxRADVXn+x5AGsbBfyw=="
+      "version": "3.38.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.38.0.tgz",
+      "integrity": "sha512-XPpwqEodRljce9KswjZShh95qJ1URisBeKCjUdq27YdenkslVe7OO0ZJhlYXAChW7OhXaRLl8AAba7IBfoIHug=="
     },
     "core-js-compat": {
-      "version": "3.37.1",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.37.1.tgz",
-      "integrity": "sha512-9TNiImhKvQqSUkOvk/mMRZzOANTiEVC7WaBNhHcKM7x+/5E1l5NvsysR19zuDQScE8k+kfQXWRN3AtS/eOSHpg==",
+      "version": "3.38.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.38.0.tgz",
+      "integrity": "sha512-75LAicdLa4OJVwFxFbQR3NdnZjNgX6ILpVcVzcC4T2smerB5lELMrJQQQoWV6TiuC/vlaFqgU2tKQx9w5s0e0A==",
       "requires": {
-        "browserslist": "^4.23.0"
+        "browserslist": "^4.23.3"
       }
     },
     "core-js-pure": {
-      "version": "3.37.1",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.37.1.tgz",
-      "integrity": "sha512-J/r5JTHSmzTxbiYYrzXg9w1VpqrYt+gexenBE9pugeyhwPZTAEJddyiReJWsLO6uNQ8xJZFbod6XC7KKwatCiA=="
+      "version": "3.38.0",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.0.tgz",
+      "integrity": "sha512-8balb/HAXo06aHP58mZMtXgD8vcnXz9tUDePgqBgJgKdmTlMt+jw3ujqniuBDQXMvTzxnMpxHFeuSM3g1jWQuQ=="
     },
     "core-util-is": {
       "version": "1.0.3",
@@ -6100,9 +6103,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.3.tgz",
-      "integrity": "sha512-QNdYSS5i8D9axWp/6XIezRObRHqaav/ur9z1VzCDUCH1XIFOr9WQk5xmgunhsTpjjgDy3oLxO/WMOVZlpUQrlA=="
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.5.tgz",
+      "integrity": "sha512-QR7/A7ZkMS8tZuoftC/jfqNkZLQO779SSW3YuZHP4eXpj3EffGLFcB/Xu9AAZQzLccTiCV+EmUo3ha4mQ9wnlA=="
     },
     "emittery": {
       "version": "0.8.1",
@@ -11299,9 +11302,9 @@
       }
     },
     "launch-editor": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.8.0.tgz",
-      "integrity": "sha512-vJranOAJrI/llyWGRQqiDM+adrw+k83fvmmx3+nV47g3+36xM15jE+zyZ6Ffel02+xSvuM0b2GDRosXZkbb6wA==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.8.1.tgz",
+      "integrity": "sha512-elBx2l/tp9z99X5H/qev8uyDywVh0VXAwEbjk8kJhnc5grOFkGh7aW6q55me9xnYbss261XtnUrysZ+XvGbhQA==",
       "requires": {
         "picocolors": "^1.0.0",
         "shell-quote": "^1.8.1"
@@ -12090,7 +12093,7 @@
       }
     },
     "pcic-react-leaflet-components": {
-      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#e17e93d5b0a7ec7d1ad9c1577344f1cba9955bf8",
+      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#b75214332c6c204e1be70b9387f301cca76b3f44",
       "from": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#add-BCVectorBaseMap",
       "requires": {
         "@testing-library/jest-dom": "^5.16.4",
@@ -12190,9 +12193,9 @@
       "integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q=="
     },
     "postcss": {
-      "version": "8.4.40",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.40.tgz",
-      "integrity": "sha512-YF2kKIUzAofPMpfH6hOi2cGnv/HrUlfucspc7pDyvv7kGdqXrfj8SCl/t8owkEgKEuu8ZcRjSOxFxVLqwChZ2Q==",
+      "version": "8.4.41",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.41.tgz",
+      "integrity": "sha512-TesUflQ0WKZqAvg52PWL6kHgLKP6xB6heTOdoYM0Wt2UHyxNa4K25EZZMgKns3BH1RLVbZCREPpLY0rhnNoHVQ==",
       "requires": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.0.1",
@@ -14756,9 +14759,9 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
     },
     "tailwindcss": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.7.tgz",
-      "integrity": "sha512-rxWZbe87YJb4OcSopb7up2Ba4U82BoiSGUdoDr3Ydrg9ckxFS/YWsvhN323GMcddgU65QRy7JndC7ahhInhvlQ==",
+      "version": "3.4.8",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.8.tgz",
+      "integrity": "sha512-GkP17r9GQkxgZ9FKHJQEnjJuKBcbFhMFzKu5slmN6NjlCuFnYJMQ8N4AZ6VrUyiRXlDtPKHkesuQ/MS913Nvdg==",
       "requires": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -14829,9 +14832,9 @@
       }
     },
     "terser": {
-      "version": "5.31.3",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.31.3.tgz",
-      "integrity": "sha512-pAfYn3NIZLyZpa83ZKigvj6Rn9c/vd5KfYGX7cN1mnzqgDcxWvrU5ZtAfIKhEXz9nRecw4z3LXkjaq96/qZqAA==",
+      "version": "5.31.4",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.31.4.tgz",
+      "integrity": "sha512-3OU03GgblDgu0g+sdnsVzhBPxnjV+WJuMmocN1qBBZDQ3ia7jZQSAkePeKbPlYAejGXUTYe1CmSaUeV51mvaIw==",
       "requires": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.8.2",
@@ -15189,9 +15192,9 @@
       "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
     },
     "undici-types": {
-      "version": "6.11.1",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.11.1.tgz",
-      "integrity": "sha512-mIDEX2ek50x0OlRgxryxsenE5XaQD4on5U2inY7RApK3SOJpofyw7uW2AyfMKkhAxXIceo2DeWGVGwyvng1GNQ=="
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.13.0.tgz",
+      "integrity": "sha512-xtFJHudx8S2DSoujjMd1WeWvn7KKWFRESZTMeL1RptAYERu29D6jphMjjY+vn96jvN3kVPDNxU/E13VTaXj6jg=="
     },
     "unherit": {
       "version": "1.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12096,7 +12096,7 @@
       }
     },
     "pcic-react-leaflet-components": {
-      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#aa1ab567db4b0f33af7610019436bebc42dd1bd8",
+      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#f1911044bc3d3898588f9f05b9de25de2151ccb8",
       "from": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#add-BCVectorBaseMap",
       "requires": {
         "@testing-library/jest-dom": "^5.16.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,25 +54,25 @@
       }
     },
     "@babel/compat-data": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.24.7.tgz",
-      "integrity": "sha512-qJzAIcv03PyaWqxRgO4mSU3lihncDT296vnyuE2O8uA4w3UHWI4S3hgeZd1L8W1Bft40w9JxJ2b412iDUFFRhw=="
+      "version": "7.24.9",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.24.9.tgz",
+      "integrity": "sha512-e701mcfApCJqMMueQI0Fb68Amflj83+dvAvHawoBpAz+GDjCIyGHzNwnefjsWJ3xiYAqqiQFoWbspGYBdb2/ng=="
     },
     "@babel/core": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.7.tgz",
-      "integrity": "sha512-nykK+LEK86ahTkX/3TgauT0ikKoNCfKHEaZYTUVupJdTLzGNvrblu4u6fa7DhZONAltdf8e662t/abY8idrd/g==",
+      "version": "7.24.9",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.9.tgz",
+      "integrity": "sha512-5e3FI4Q3M3Pbr21+5xJwCv6ZT6KmGkI0vw3Tozy5ODAQFTIWe37iT8Cr7Ice2Ntb+M3iSKCEWMB1MBgKrW3whg==",
       "requires": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.24.7",
-        "@babel/generator": "^7.24.7",
-        "@babel/helper-compilation-targets": "^7.24.7",
-        "@babel/helper-module-transforms": "^7.24.7",
-        "@babel/helpers": "^7.24.7",
-        "@babel/parser": "^7.24.7",
+        "@babel/generator": "^7.24.9",
+        "@babel/helper-compilation-targets": "^7.24.8",
+        "@babel/helper-module-transforms": "^7.24.9",
+        "@babel/helpers": "^7.24.8",
+        "@babel/parser": "^7.24.8",
         "@babel/template": "^7.24.7",
-        "@babel/traverse": "^7.24.7",
-        "@babel/types": "^7.24.7",
+        "@babel/traverse": "^7.24.8",
+        "@babel/types": "^7.24.9",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -93,9 +93,9 @@
       }
     },
     "@babel/eslint-parser": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.24.7.tgz",
-      "integrity": "sha512-SO5E3bVxDuxyNxM5agFv480YA2HO6ohZbGxbazZdIk3KQOPOGVNw6q78I9/lbviIf95eq6tPozeYnJLbjnC8IA==",
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.24.8.tgz",
+      "integrity": "sha512-nYAikI4XTGokU2QX7Jx+v4rxZKhKivaQaREZjuW3mrJrbdWJ5yUfohnoUULge+zEEaKjPYNxhoRgUKktjXtbwA==",
       "requires": {
         "@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
         "eslint-visitor-keys": "^2.1.0",
@@ -115,11 +115,11 @@
       }
     },
     "@babel/generator": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.7.tgz",
-      "integrity": "sha512-oipXieGC3i45Y1A41t4tAqpnEZWgB/lC6Ehh6+rOviR5XWpTtMmLN+fGjz9vOiNRt0p6RtO6DtD0pdU3vpqdSA==",
+      "version": "7.24.10",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.10.tgz",
+      "integrity": "sha512-o9HBZL1G2129luEUlG1hB4N/nlYNWHnpwlND9eOMclRqqu1YDy2sSYVCFUZwl8I1Gxh+QSRrP2vD7EpUmFVXxg==",
       "requires": {
-        "@babel/types": "^7.24.7",
+        "@babel/types": "^7.24.9",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^2.5.1"
@@ -154,13 +154,13 @@
       }
     },
     "@babel/helper-compilation-targets": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.24.7.tgz",
-      "integrity": "sha512-ctSdRHBi20qWOfy27RUb4Fhp07KSJ3sXcuSvTrXrc4aG8NSYDo1ici3Vhg9bg69y5bj0Mr1lh0aeEgTvc12rMg==",
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.24.8.tgz",
+      "integrity": "sha512-oU+UoqCHdp+nWVDkpldqIQL/i/bvAv53tRqLG/s+cOXxe66zOYLU7ar/Xs3LdmBihrUMEUhwu6dMZwbNOYDwvw==",
       "requires": {
-        "@babel/compat-data": "^7.24.7",
-        "@babel/helper-validator-option": "^7.24.7",
-        "browserslist": "^4.22.2",
+        "@babel/compat-data": "^7.24.8",
+        "@babel/helper-validator-option": "^7.24.8",
+        "browserslist": "^4.23.1",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
       },
@@ -173,14 +173,14 @@
       }
     },
     "@babel/helper-create-class-features-plugin": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.24.7.tgz",
-      "integrity": "sha512-kTkaDl7c9vO80zeX1rJxnuRpEsD5tA81yh11X1gQo+PhSti3JS+7qeZo9U4RHobKRiFPKaGK3svUAeb8D0Q7eg==",
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.24.8.tgz",
+      "integrity": "sha512-4f6Oqnmyp2PP3olgUMmOwC3akxSm5aBYraQ6YDdKy7NcAMkDECHWG0DEnV6M2UAkERgIBhYt8S27rURPg7SxWA==",
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.24.7",
         "@babel/helper-environment-visitor": "^7.24.7",
         "@babel/helper-function-name": "^7.24.7",
-        "@babel/helper-member-expression-to-functions": "^7.24.7",
+        "@babel/helper-member-expression-to-functions": "^7.24.8",
         "@babel/helper-optimise-call-expression": "^7.24.7",
         "@babel/helper-replace-supers": "^7.24.7",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.24.7",
@@ -250,12 +250,12 @@
       }
     },
     "@babel/helper-member-expression-to-functions": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.24.7.tgz",
-      "integrity": "sha512-LGeMaf5JN4hAT471eJdBs/GK1DoYIJ5GCtZN/EsL6KUiiDZOvO/eKE11AMZJa2zP4zk4qe9V2O/hxAmkRc8p6w==",
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.24.8.tgz",
+      "integrity": "sha512-LABppdt+Lp/RlBxqrh4qgf1oEH/WxdzQNDJIu5gC/W1GyvPVrOBiItmmM8wan2fm4oYqFuFfkXmlGpLQhPY8CA==",
       "requires": {
-        "@babel/traverse": "^7.24.7",
-        "@babel/types": "^7.24.7"
+        "@babel/traverse": "^7.24.8",
+        "@babel/types": "^7.24.8"
       }
     },
     "@babel/helper-module-imports": {
@@ -268,9 +268,9 @@
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.24.7.tgz",
-      "integrity": "sha512-1fuJEwIrp+97rM4RWdO+qrRsZlAeL1lQJoPqtCYWv0NL115XM93hIH4CSRln2w52SqvmY5hqdtauB6QFCDiZNQ==",
+      "version": "7.24.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.24.9.tgz",
+      "integrity": "sha512-oYbh+rtFKj/HwBQkFlUzvcybzklmVdVV3UU+mN7n2t/q3yGHbuVdNxyFvSBO1tfvjyArpHNcWMAzsSPdyI46hw==",
       "requires": {
         "@babel/helper-environment-visitor": "^7.24.7",
         "@babel/helper-module-imports": "^7.24.7",
@@ -288,9 +288,9 @@
       }
     },
     "@babel/helper-plugin-utils": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.7.tgz",
-      "integrity": "sha512-Rq76wjt7yz9AAc1KnlRKNAi/dMSVWgDRx43FHoJEbcYU6xOWaE2dVPwcdTukJrjxS65GITyfbvEYHvkirZ6uEg=="
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.8.tgz",
+      "integrity": "sha512-FFWx5142D8h2Mgr/iPVGH5G7w6jDn4jUSpZTyDnQO0Yn7Ks2Kuz6Pci8H6MPCoUJegd/UZQ3tAvfLCxQSnWWwg=="
     },
     "@babel/helper-remap-async-to-generator": {
       "version": "7.24.7",
@@ -339,9 +339,9 @@
       }
     },
     "@babel/helper-string-parser": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.7.tgz",
-      "integrity": "sha512-7MbVt6xrwFQbunH2DNQsAP5sTGxfqQtErvBIvIMi6EQnbgUOuVYanvREcmFrOPhoXBrTtjhhP+lW+o5UfK+tDg=="
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.8.tgz",
+      "integrity": "sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ=="
     },
     "@babel/helper-validator-identifier": {
       "version": "7.24.7",
@@ -349,9 +349,9 @@
       "integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w=="
     },
     "@babel/helper-validator-option": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.24.7.tgz",
-      "integrity": "sha512-yy1/KvjhV/ZCL+SM7hBrvnZJ3ZuT9OuZgIJAGpPEToANvc3iM6iDvBnRjtElWibHU6n8/LPR/EjX9EtIEYO3pw=="
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.24.8.tgz",
+      "integrity": "sha512-xb8t9tD1MHLungh/AIoWYN+gVHaB9kwlu8gffXGSt3FFEIT7RjS+xWbc2vUD1UTZdIpKj/ab3rdqJ7ufngyi2Q=="
     },
     "@babel/helper-wrap-function": {
       "version": "7.24.7",
@@ -365,12 +365,12 @@
       }
     },
     "@babel/helpers": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.7.tgz",
-      "integrity": "sha512-NlmJJtvcw72yRJRcnCmGvSi+3jDEg8qFu3z0AFoymmzLx5ERVWyzd9kVXr7Th9/8yIJi2Zc6av4Tqz3wFs8QWg==",
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.8.tgz",
+      "integrity": "sha512-gV2265Nkcz7weJJfvDoAEVzC1e2OTDpkGbEsebse8koXUJUXPsCMi7sRo/+SPMuMZ9MtUPnGwITTnQnU5YjyaQ==",
       "requires": {
         "@babel/template": "^7.24.7",
-        "@babel/types": "^7.24.7"
+        "@babel/types": "^7.24.8"
       }
     },
     "@babel/highlight": {
@@ -385,9 +385,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.7.tgz",
-      "integrity": "sha512-9uUYRm6OqQrCqQdG1iCBwBPZgN8ciDBro2nIOFaiRz1/BCxaI7CNvQbDHvsArAC7Tw9Hda/B3U+6ui9u4HWXPw=="
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.8.tgz",
+      "integrity": "sha512-WzfbgXOkGzZiXXCqk43kKwZjzwx4oulxZi3nq2TYL9mOjQv6kYwul9mz6ID36njuL7Xkp6nJEfok848Zj10j/w=="
     },
     "@babel/plugin-bugfix-firefox-class-in-computed-class-key": {
       "version": "7.24.7",
@@ -736,15 +736,15 @@
       }
     },
     "@babel/plugin-transform-classes": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.24.7.tgz",
-      "integrity": "sha512-CFbbBigp8ln4FU6Bpy6g7sE8B/WmCmzvivzUC6xDAdWVsjYTXijpuuGJmYkAaoWAzcItGKT3IOAbxRItZ5HTjw==",
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.24.8.tgz",
+      "integrity": "sha512-VXy91c47uujj758ud9wx+OMgheXm4qJfyhj1P18YvlrQkNOSrwsteHk+EFS3OMGfhMhpZa0A+81eE7G4QC+3CA==",
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.24.7",
-        "@babel/helper-compilation-targets": "^7.24.7",
+        "@babel/helper-compilation-targets": "^7.24.8",
         "@babel/helper-environment-visitor": "^7.24.7",
         "@babel/helper-function-name": "^7.24.7",
-        "@babel/helper-plugin-utils": "^7.24.7",
+        "@babel/helper-plugin-utils": "^7.24.8",
         "@babel/helper-replace-supers": "^7.24.7",
         "@babel/helper-split-export-declaration": "^7.24.7",
         "globals": "^11.1.0"
@@ -760,11 +760,11 @@
       }
     },
     "@babel/plugin-transform-destructuring": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.24.7.tgz",
-      "integrity": "sha512-19eJO/8kdCQ9zISOf+SEUJM/bAUIsvY3YDnXZTupUCQ8LgrWnsG/gFB9dvXqdXnRXMAM8fvt7b0CBKQHNGy1mw==",
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.24.8.tgz",
+      "integrity": "sha512-36e87mfY8TnRxc7yc6M9g9gOB7rKgSahqkIKwLpz4Ppk2+zC2Cy1is0uwtuSG6AE4zlTOUa+7JGz9jCJGLqQFQ==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.24.7"
+        "@babel/helper-plugin-utils": "^7.24.8"
       }
     },
     "@babel/plugin-transform-dotall-regex": {
@@ -883,12 +883,12 @@
       }
     },
     "@babel/plugin-transform-modules-commonjs": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.24.7.tgz",
-      "integrity": "sha512-iFI8GDxtevHJ/Z22J5xQpVqFLlMNstcLXh994xifFwxxGslr2ZXXLWgtBeLctOD63UFDArdvN6Tg8RFw+aEmjQ==",
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.24.8.tgz",
+      "integrity": "sha512-WHsk9H8XxRs3JXKWFiqtQebdh9b/pTk4EgueygFzYlTKAg0Ud985mSevdNjdXdFBATSKVJGQXP1tv6aGbssLKA==",
       "requires": {
-        "@babel/helper-module-transforms": "^7.24.7",
-        "@babel/helper-plugin-utils": "^7.24.7",
+        "@babel/helper-module-transforms": "^7.24.8",
+        "@babel/helper-plugin-utils": "^7.24.8",
         "@babel/helper-simple-access": "^7.24.7"
       }
     },
@@ -977,11 +977,11 @@
       }
     },
     "@babel/plugin-transform-optional-chaining": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.24.7.tgz",
-      "integrity": "sha512-tK+0N9yd4j+x/4hxF3F0e0fu/VdcxU18y5SevtyM/PCFlQvXbR0Zmlo2eBrKtVipGNFzpq56o8WsIIKcJFUCRQ==",
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.24.8.tgz",
+      "integrity": "sha512-5cTOLSMs9eypEy8JUVvIKOu6NgvbJMnpG62VpIHrTmROdQ+L5mDAaI40g25k5vXti55JWNX5jCkq3HZxXBQANw==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.24.7",
+        "@babel/helper-plugin-utils": "^7.24.8",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.24.7",
         "@babel/plugin-syntax-optional-chaining": "^7.8.3"
       }
@@ -1138,21 +1138,21 @@
       }
     },
     "@babel/plugin-transform-typeof-symbol": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.24.7.tgz",
-      "integrity": "sha512-VtR8hDy7YLB7+Pet9IarXjg/zgCMSF+1mNS/EQEiEaUPoFXCVsHG64SIxcaaI2zJgRiv+YmgaQESUfWAdbjzgg==",
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.24.8.tgz",
+      "integrity": "sha512-adNTUpDCVnmAE58VEqKlAA6ZBlNkMnWD0ZcW76lyNFN3MJniyGFZfNwERVk8Ap56MCnXztmDr19T4mPTztcuaw==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.24.7"
+        "@babel/helper-plugin-utils": "^7.24.8"
       }
     },
     "@babel/plugin-transform-typescript": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.24.7.tgz",
-      "integrity": "sha512-iLD3UNkgx2n/HrjBesVbYX6j0yqn/sJktvbtKKgcaLIQ4bTTQ8obAypc1VpyHPD2y4Phh9zHOaAt8e/L14wCpw==",
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.24.8.tgz",
+      "integrity": "sha512-CgFgtN61BbdOGCP4fLaAMOPkzWUh6yQZNMr5YSt8uz2cZSSiQONCQFWqsE4NeVfOIhqDOlS9CR3WD91FzMeB2Q==",
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.24.7",
-        "@babel/helper-create-class-features-plugin": "^7.24.7",
-        "@babel/helper-plugin-utils": "^7.24.7",
+        "@babel/helper-create-class-features-plugin": "^7.24.8",
+        "@babel/helper-plugin-utils": "^7.24.8",
         "@babel/plugin-syntax-typescript": "^7.24.7"
       }
     },
@@ -1192,14 +1192,14 @@
       }
     },
     "@babel/preset-env": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.24.7.tgz",
-      "integrity": "sha512-1YZNsc+y6cTvWlDHidMBsQZrZfEFjRIo/BZCT906PMdzOyXtSLTgqGdrpcuTDCXyd11Am5uQULtDIcCfnTc8fQ==",
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.24.8.tgz",
+      "integrity": "sha512-vObvMZB6hNWuDxhSaEPTKCwcqkAIuDtE+bQGn4XMXne1DSLzFVY8Vmj1bm+mUQXYNN8NmaQEO+r8MMbzPr1jBQ==",
       "requires": {
-        "@babel/compat-data": "^7.24.7",
-        "@babel/helper-compilation-targets": "^7.24.7",
-        "@babel/helper-plugin-utils": "^7.24.7",
-        "@babel/helper-validator-option": "^7.24.7",
+        "@babel/compat-data": "^7.24.8",
+        "@babel/helper-compilation-targets": "^7.24.8",
+        "@babel/helper-plugin-utils": "^7.24.8",
+        "@babel/helper-validator-option": "^7.24.8",
         "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.24.7",
         "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.24.7",
         "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.24.7",
@@ -1230,9 +1230,9 @@
         "@babel/plugin-transform-block-scoping": "^7.24.7",
         "@babel/plugin-transform-class-properties": "^7.24.7",
         "@babel/plugin-transform-class-static-block": "^7.24.7",
-        "@babel/plugin-transform-classes": "^7.24.7",
+        "@babel/plugin-transform-classes": "^7.24.8",
         "@babel/plugin-transform-computed-properties": "^7.24.7",
-        "@babel/plugin-transform-destructuring": "^7.24.7",
+        "@babel/plugin-transform-destructuring": "^7.24.8",
         "@babel/plugin-transform-dotall-regex": "^7.24.7",
         "@babel/plugin-transform-duplicate-keys": "^7.24.7",
         "@babel/plugin-transform-dynamic-import": "^7.24.7",
@@ -1245,7 +1245,7 @@
         "@babel/plugin-transform-logical-assignment-operators": "^7.24.7",
         "@babel/plugin-transform-member-expression-literals": "^7.24.7",
         "@babel/plugin-transform-modules-amd": "^7.24.7",
-        "@babel/plugin-transform-modules-commonjs": "^7.24.7",
+        "@babel/plugin-transform-modules-commonjs": "^7.24.8",
         "@babel/plugin-transform-modules-systemjs": "^7.24.7",
         "@babel/plugin-transform-modules-umd": "^7.24.7",
         "@babel/plugin-transform-named-capturing-groups-regex": "^7.24.7",
@@ -1255,7 +1255,7 @@
         "@babel/plugin-transform-object-rest-spread": "^7.24.7",
         "@babel/plugin-transform-object-super": "^7.24.7",
         "@babel/plugin-transform-optional-catch-binding": "^7.24.7",
-        "@babel/plugin-transform-optional-chaining": "^7.24.7",
+        "@babel/plugin-transform-optional-chaining": "^7.24.8",
         "@babel/plugin-transform-parameters": "^7.24.7",
         "@babel/plugin-transform-private-methods": "^7.24.7",
         "@babel/plugin-transform-private-property-in-object": "^7.24.7",
@@ -1266,7 +1266,7 @@
         "@babel/plugin-transform-spread": "^7.24.7",
         "@babel/plugin-transform-sticky-regex": "^7.24.7",
         "@babel/plugin-transform-template-literals": "^7.24.7",
-        "@babel/plugin-transform-typeof-symbol": "^7.24.7",
+        "@babel/plugin-transform-typeof-symbol": "^7.24.8",
         "@babel/plugin-transform-unicode-escapes": "^7.24.7",
         "@babel/plugin-transform-unicode-property-regex": "^7.24.7",
         "@babel/plugin-transform-unicode-regex": "^7.24.7",
@@ -1275,7 +1275,7 @@
         "babel-plugin-polyfill-corejs2": "^0.4.10",
         "babel-plugin-polyfill-corejs3": "^0.10.4",
         "babel-plugin-polyfill-regenerator": "^0.6.1",
-        "core-js-compat": "^3.31.0",
+        "core-js-compat": "^3.37.1",
         "semver": "^6.3.1"
       },
       "dependencies": {
@@ -1327,9 +1327,9 @@
       "integrity": "sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA=="
     },
     "@babel/runtime": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.7.tgz",
-      "integrity": "sha512-UwgBRMjJP+xv857DCngvqXI3Iq6J4v0wXmwc6sapg+zyhbwmQX67LUEFrkK5tbyJ30jGuG3ZvWpBiB9LCy1kWw==",
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.8.tgz",
+      "integrity": "sha512-5F7SDGs1T72ZczbRwbGO9lQi0NLjQxzl6i4lJxLxfW9U5UluCSyEJeniWvnhl3/euNiqQVbo8zruhsDfid0esA==",
       "requires": {
         "regenerator-runtime": "^0.14.0"
       }
@@ -1345,28 +1345,28 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.7.tgz",
-      "integrity": "sha512-yb65Ed5S/QAcewNPh0nZczy9JdYXkkAbIsEo+P7BE7yO3txAY30Y/oPa3QkQ5It3xVG2kpKMg9MsdxZaO31uKA==",
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.8.tgz",
+      "integrity": "sha512-t0P1xxAPzEDcEPmjprAQq19NWum4K0EQPjMwZQZbHt+GiZqvjCHjj755Weq1YRPVzBI+3zSfvScfpnuIecVFJQ==",
       "requires": {
         "@babel/code-frame": "^7.24.7",
-        "@babel/generator": "^7.24.7",
+        "@babel/generator": "^7.24.8",
         "@babel/helper-environment-visitor": "^7.24.7",
         "@babel/helper-function-name": "^7.24.7",
         "@babel/helper-hoist-variables": "^7.24.7",
         "@babel/helper-split-export-declaration": "^7.24.7",
-        "@babel/parser": "^7.24.7",
-        "@babel/types": "^7.24.7",
+        "@babel/parser": "^7.24.8",
+        "@babel/types": "^7.24.8",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       }
     },
     "@babel/types": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.7.tgz",
-      "integrity": "sha512-XEFXSlxiG5td2EJRe8vOmRbaXVgfcBlszKujvVmWIK/UpywWljQCfzAv3RQCGujWQ1RD4YYWEAqDXfuJiy8f5Q==",
+      "version": "7.24.9",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.9.tgz",
+      "integrity": "sha512-xm8XrMKz0IlUdocVbYJe0Z9xEgidU7msskG8BbhnTPK/HZ2z/7FP7ykqPgrUH+C+r414mNfNWam1f2vqOjqjYQ==",
       "requires": {
-        "@babel/helper-string-parser": "^7.24.7",
+        "@babel/helper-string-parser": "^7.24.8",
         "@babel/helper-validator-identifier": "^7.24.7",
         "to-fast-properties": "^2.0.0"
       }
@@ -1587,9 +1587,9 @@
       }
     },
     "@eslint-community/regexpp": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.1.tgz",
-      "integrity": "sha512-Zm2NGpWELsQAD1xsJzGQpYfvICSsFkEpU0jxBjfdC6uNEWXcHnfs9hScFWtXVDVl+rBQJGrl4g1vcKIejpH9dA=="
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.11.0.tgz",
+      "integrity": "sha512-G/M/tIiMrTAxEWRfLfQJMmGNX28IxBg4PBz8XqQhqUHLFI6TL2htpIB1iQCj144V5ee/JaKyT9/WZ0MGZWfA7A=="
     },
     "@eslint/eslintrc": {
       "version": "2.1.4",
@@ -1694,19 +1694,6 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
           "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="
         },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-        },
         "string-width": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
@@ -1717,57 +1704,12 @@
             "strip-ansi": "^7.0.1"
           }
         },
-        "string-width-cjs": {
-          "version": "npm:string-width@4.2.3",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-          "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.1"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "5.0.1",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-              "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
-            },
-            "emoji-regex": {
-              "version": "8.0.0",
-              "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-              "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-            },
-            "strip-ansi": {
-              "version": "6.0.1",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-              "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-              "requires": {
-                "ansi-regex": "^5.0.1"
-              }
-            }
-          }
-        },
         "strip-ansi": {
           "version": "7.1.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
           "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
           "requires": {
             "ansi-regex": "^6.0.1"
-          }
-        },
-        "strip-ansi-cjs": {
-          "version": "npm:strip-ansi@6.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-          "requires": {
-            "ansi-regex": "^5.0.1"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "5.0.1",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-              "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
-            }
           }
         },
         "wrap-ansi": {
@@ -1778,54 +1720,6 @@
             "ansi-styles": "^6.1.0",
             "string-width": "^5.0.1",
             "strip-ansi": "^7.0.1"
-          }
-        },
-        "wrap-ansi-cjs": {
-          "version": "npm:wrap-ansi@7.0.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-          "requires": {
-            "ansi-styles": "^4.0.0",
-            "string-width": "^4.1.0",
-            "strip-ansi": "^6.0.0"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "5.0.1",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-              "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
-            },
-            "ansi-styles": {
-              "version": "4.3.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-              "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-              "requires": {
-                "color-convert": "^2.0.1"
-              }
-            },
-            "emoji-regex": {
-              "version": "8.0.0",
-              "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-              "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-            },
-            "string-width": {
-              "version": "4.2.3",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-              "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-              "requires": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-              }
-            },
-            "strip-ansi": {
-              "version": "6.0.1",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-              "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-              "requires": {
-                "ansi-regex": "^5.0.1"
-              }
-            }
           }
         }
       }
@@ -2945,9 +2839,9 @@
       }
     },
     "@jridgewell/sourcemap-codec": {
-      "version": "1.4.15",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="
     },
     "@jridgewell/trace-mapping": {
       "version": "0.3.9",
@@ -3529,9 +3423,9 @@
       }
     },
     "@types/eslint": {
-      "version": "8.56.10",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.10.tgz",
-      "integrity": "sha512-Shavhk87gCtY2fhXDctcfS3e6FdxWkCx1iUZ9eEUbh7rTqlZT0/IzOkCOVt0fCjcFuZ9FPYfuezTBImfHCDBGQ==",
+      "version": "8.56.11",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.11.tgz",
+      "integrity": "sha512-sVBpJMf7UPo/wGecYOpk2aQya2VUGeHhe38WG7/mN5FufNSubf5VT9Uh9Uyp8/eLJpu1/tuhJ/qTo4mhSB4V4Q==",
       "requires": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -3563,9 +3457,9 @@
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.19.3",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.3.tgz",
-      "integrity": "sha512-KOzM7MhcBFlmnlr/fzISFF5vGWVSvN6fTd4T+ExOt08bA/dA5kpSzY52nMsI1KDFmUREpJelPYyuslLRSjjgCg==",
+      "version": "4.19.5",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.5.tgz",
+      "integrity": "sha512-y6W03tvrACO72aijJ5uF02FRq5cgDR9lUxddQ8vyF+GvmjJQqbzDcJngEjURc+ZsG31VI3hODNZJ2URj86pzmg==",
       "requires": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -3650,9 +3544,9 @@
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w=="
     },
     "@types/node": {
-      "version": "20.14.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.2.tgz",
-      "integrity": "sha512-xyu6WAMVwv6AKFLB+e/7ySZVr/0zLCzOa7rSpq6jNwpqOrUbcACDWC+53d4n2QHOnDou0fbIsg8wZu/sxrnI4Q==",
+      "version": "20.14.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.12.tgz",
+      "integrity": "sha512-r7wNXakLeSsGT0H1AU863vS2wa5wBOK4bWMjZz2wj+8nBx+m5PeIn0k8AloSLpRuiwdRQZwarZqHE4FNArPuJQ==",
       "requires": {
         "undici-types": "~5.26.4"
       }
@@ -3804,9 +3698,9 @@
       "integrity": "sha512-D1XC7WK8K+zZEveUPY+cf4+kgauk8N4eHr/XIHXGlGYkHLud6hK9lYfZk1ry1TNh798cZUCgb6MqGEG8DkJt6Q=="
     },
     "@types/ws": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.10.tgz",
-      "integrity": "sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==",
+      "version": "8.5.11",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.11.tgz",
+      "integrity": "sha512-4+q7P5h3SpJxaBft0Dzpbr6lmMaqh0Jr2tbhJZ/luAwvD7ohSCniYkwz/pLxuT2h0EOa6QADgJj1Ko+TzRfZ+w==",
       "requires": {
         "@types/node": "*"
       }
@@ -4100,9 +3994,9 @@
       }
     },
     "acorn": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.0.tgz",
-      "integrity": "sha512-RTvkC4w+KNXrM39/lWCUaG0IbRkWdCv7W/IOW9oU6SawyxulvkQy5HQPVTKxEjczcUvapcrw3cFx/60VN/NRNw=="
+      "version": "8.12.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
+      "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg=="
     },
     "acorn-globals": {
       "version": "6.0.0",
@@ -4166,14 +4060,14 @@
       }
     },
     "ajv": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.16.0.tgz",
-      "integrity": "sha512-F0twR8U1ZU67JIEtekUcLkXkoO5mMMmgGD8sK/xUFzJ805jxHQl92hImFAqqXMyMYjSPOyUPAwHYhB72g5sTXw==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "requires": {
         "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
         "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.4.1"
+        "require-from-string": "^2.0.2"
       }
     },
     "ajv-formats": {
@@ -4354,17 +4248,6 @@
         "is-string": "^1.0.7"
       }
     },
-    "array.prototype.toreversed": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/array.prototype.toreversed/-/array.prototype.toreversed-1.1.2.tgz",
-      "integrity": "sha512-wwDCoT4Ck4Cz7sLtgUmzR5UV3YF5mFHUlbChCzZBQZ+0m2cl/DH3tKgvphv1nKgFsJ48oCSg6p91q2Vm0I/ZMA==",
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1",
-        "es-shim-unscopables": "^1.0.0"
-      }
-    },
     "array.prototype.tosorted": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.4.tgz",
@@ -4439,9 +4322,9 @@
       }
     },
     "axe-core": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.7.0.tgz",
-      "integrity": "sha512-M0JtH+hlOL5pLQwHOLNYZaXuhqmvS8oExsqB1SBYgA4Dk7u/xx+YdGHXaK5pyUfed5mYXdlYiphWq3G8cRi5JQ=="
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.9.1.tgz",
+      "integrity": "sha512-QbUdXJVTpvUTHU7871ppZkdOLBeGUKBQWHkHrvN2V9IQWGMt61zf3B45BtzjxEJzYuj0JBjBZP/hmYS/R9pmAw=="
     },
     "axios": {
       "version": "0.28.1",
@@ -4451,26 +4334,14 @@
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
-      },
-      "dependencies": {
-        "form-data": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.8",
-            "mime-types": "^2.1.12"
-          }
-        }
       }
     },
     "axobject-query": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-3.2.1.tgz",
-      "integrity": "sha512-jsyHu61e6N4Vbz/v18DHwWYKK0bSWLqn47eeDSKPB7m8tqMHF9YJ+mhIk2lVteyZrY8tnSj/jHOv4YiTCuCJgg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-3.1.1.tgz",
+      "integrity": "sha512-goKlv8DZrK9hUh975fnHzhNIO4jUnFCfv/dszV5VwUGDFjI6vQ2VwoyjYjYNEbBE8AH87TduWP5uyDR1D+Iteg==",
       "requires": {
-        "dequal": "^2.0.3"
+        "deep-equal": "^2.0.5"
       }
     },
     "babel-jest": {
@@ -4903,14 +4774,14 @@
       "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow=="
     },
     "browserslist": {
-      "version": "4.23.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.1.tgz",
-      "integrity": "sha512-TUfofFo/KsK/bWZ9TWQ5O26tsWW4Uhmt8IYklbnUa70udB6P2wA7w7o4PY4muaEPBQaAX+CEnmmIA41NVHtPVw==",
+      "version": "4.23.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.2.tgz",
+      "integrity": "sha512-qkqSyistMYdxAcw+CzbZwlBy8AGmS/eEWs+sEV5TnLRGDOL+C5M2EnH6tlZyg0YoAxGJAFKh61En9BR941GnHA==",
       "requires": {
-        "caniuse-lite": "^1.0.30001629",
-        "electron-to-chromium": "^1.4.796",
+        "caniuse-lite": "^1.0.30001640",
+        "electron-to-chromium": "^1.4.820",
         "node-releases": "^2.0.14",
-        "update-browserslist-db": "^1.0.16"
+        "update-browserslist-db": "^1.1.0"
       }
     },
     "bser": {
@@ -5008,9 +4879,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001634",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001634.tgz",
-      "integrity": "sha512-fbBYXQ9q3+yp1q1gBk86tOFs4pyn/yxFm5ZNP18OXJDfA3txImOY9PhfxVggZ4vRHDqoU8NrKU81eN0OtzOgRA=="
+      "version": "1.0.30001643",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001643.tgz",
+      "integrity": "sha512-ERgWGNleEilSrHM6iUz/zJNSQTP8Mr21wDWpdgvRwcTXGAq6jMtOUPP4dqFPTdKqZ2wKTdtB+uucZ3MRpAUSmg=="
     },
     "case-sensitive-paths-webpack-plugin": {
       "version": "2.4.0",
@@ -6251,9 +6122,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.802",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.802.tgz",
-      "integrity": "sha512-TnTMUATbgNdPXVSHsxvNVSG0uEd6cSZsANjm8c9HbvflZVVn1yTRcmVXYT1Ma95/ssB/Dcd30AHweH2TE+dNpA=="
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.1.tgz",
+      "integrity": "sha512-FKbOCOQ5QRB3VlIbl1LZQefWIYwszlBloaXcY2rbfpu9ioJnNh3TK03YtIDKDo3WKBi8u+YV4+Fn2CkEozgf4w=="
     },
     "emittery": {
       "version": "0.8.1",
@@ -6285,9 +6156,9 @@
       "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w=="
     },
     "enhanced-resolve": {
-      "version": "5.17.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.0.tgz",
-      "integrity": "sha512-dwDPwZL0dmye8Txp2gzFmA6sxALaSvdRDjPH0viLcKrtlOL3tw62nWWweVD1SdILDTJrbrL6tdWVN58Wo6U3eA==",
+      "version": "5.17.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.1.tgz",
+      "integrity": "sha512-LMHl3dXhTcfv8gM4kEzIUeTQ+7fpdA0l2tUf34BddXPkz2A5xJ5L/Pchd5BL6rdccM9QGvu0sWZzK1Z1t4wwyg==",
       "requires": {
         "graceful-fs": "^4.2.4",
         "tapable": "^2.2.0"
@@ -6423,9 +6294,9 @@
       }
     },
     "es-module-lexer": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.5.3.tgz",
-      "integrity": "sha512-i1gCgmR9dCl6Vil6UKPI/trA69s08g/syhiDK9TG0Nf1RJjjFI+AzoWW7sPufzkgYAn861skuCwJa0pIIHYxvg=="
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.5.4.tgz",
+      "integrity": "sha512-MVNK56NiMrOwitFB7cqDwq0CQutbw+0BvLshJSse0MUNU+y1FC3bUS/AQg7oUng+/wKrrki7JfmwtVHkVfPLlw=="
     },
     "es-object-atoms": {
       "version": "1.0.0",
@@ -6822,51 +6693,61 @@
       }
     },
     "eslint-plugin-jsx-a11y": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.8.0.tgz",
-      "integrity": "sha512-Hdh937BS3KdwwbBaKd5+PLCOmYY6U4f2h9Z2ktwtNKvIdIEu137rjYbcb9ApSbVJfWxANNuiKTD/9tOKjK9qOA==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.9.0.tgz",
+      "integrity": "sha512-nOFOCaJG2pYqORjK19lqPqxMO/JpvdCZdPtNdxY3kvom3jTvkAbOvQvD8wuD0G8BYR0IGAGYDlzqWJOh/ybn2g==",
       "requires": {
-        "@babel/runtime": "^7.23.2",
-        "aria-query": "^5.3.0",
-        "array-includes": "^3.1.7",
+        "aria-query": "~5.1.3",
+        "array-includes": "^3.1.8",
         "array.prototype.flatmap": "^1.3.2",
         "ast-types-flow": "^0.0.8",
-        "axe-core": "=4.7.0",
-        "axobject-query": "^3.2.1",
+        "axe-core": "^4.9.1",
+        "axobject-query": "~3.1.1",
         "damerau-levenshtein": "^1.0.8",
         "emoji-regex": "^9.2.2",
-        "es-iterator-helpers": "^1.0.15",
-        "hasown": "^2.0.0",
+        "es-iterator-helpers": "^1.0.19",
+        "hasown": "^2.0.2",
         "jsx-ast-utils": "^3.3.5",
         "language-tags": "^1.0.9",
         "minimatch": "^3.1.2",
-        "object.entries": "^1.1.7",
-        "object.fromentries": "^2.0.7"
+        "object.fromentries": "^2.0.8",
+        "safe-regex-test": "^1.0.3",
+        "string.prototype.includes": "^2.0.0"
+      },
+      "dependencies": {
+        "aria-query": {
+          "version": "5.1.3",
+          "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
+          "integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
+          "requires": {
+            "deep-equal": "^2.0.5"
+          }
+        }
       }
     },
     "eslint-plugin-react": {
-      "version": "7.34.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.34.2.tgz",
-      "integrity": "sha512-2HCmrU+/JNigDN6tg55cRDKCQWicYAPB38JGSFDQt95jDm8rrvSUo7YPkOIm5l6ts1j1zCvysNcasvfTMQzUOw==",
+      "version": "7.35.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.35.0.tgz",
+      "integrity": "sha512-v501SSMOWv8gerHkk+IIQBkcGRGrO2nfybfj5pLxuJNFTPxxA3PSryhXTK+9pNbtkggheDdsC0E9Q8CuPk6JKA==",
       "requires": {
         "array-includes": "^3.1.8",
         "array.prototype.findlast": "^1.2.5",
         "array.prototype.flatmap": "^1.3.2",
-        "array.prototype.toreversed": "^1.1.2",
-        "array.prototype.tosorted": "^1.1.3",
+        "array.prototype.tosorted": "^1.1.4",
         "doctrine": "^2.1.0",
         "es-iterator-helpers": "^1.0.19",
         "estraverse": "^5.3.0",
+        "hasown": "^2.0.2",
         "jsx-ast-utils": "^2.4.1 || ^3.0.0",
         "minimatch": "^3.1.2",
         "object.entries": "^1.1.8",
         "object.fromentries": "^2.0.8",
-        "object.hasown": "^1.1.4",
         "object.values": "^1.2.0",
         "prop-types": "^15.8.1",
         "resolve": "^2.0.0-next.5",
         "semver": "^6.3.1",
-        "string.prototype.matchall": "^4.0.11"
+        "string.prototype.matchall": "^4.0.11",
+        "string.prototype.repeat": "^1.0.0"
       },
       "dependencies": {
         "doctrine": {
@@ -6986,9 +6867,9 @@
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "esquery": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
-      "integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
+      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
       "requires": {
         "estraverse": "^5.1.0"
       },
@@ -7172,6 +7053,11 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
+    },
+    "fast-uri": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.1.tgz",
+      "integrity": "sha512-MWipKbbYiYI0UC7cl8m/i/IWTqfC8YXsqjzybjddLsFjStroQzsHXkc73JutMvBiXmOvapk+axIl79ig5t55Bw=="
     },
     "fastq": {
       "version": "1.17.1",
@@ -7373,9 +7259,9 @@
       }
     },
     "foreground-child": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.2.0.tgz",
-      "integrity": "sha512-CrWQNaEl1/6WeZoarcM9LHupTo3RpZO2Pdk1vktwzPiQTsJnAKJmm3TACKeG5UZbWDfaH2AbvYxzP96y0MT7fA==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.2.1.tgz",
+      "integrity": "sha512-PXUUyLqrR2XCWICfv6ukppP96sdFwWbNEnfEMt7jNsISjMsvaLNinAHNDYyvkyU+SZG2BTSbT5NjG+vZslfGTA==",
       "requires": {
         "cross-spawn": "^7.0.0",
         "signal-exit": "^4.0.1"
@@ -7513,9 +7399,9 @@
       }
     },
     "form-data": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
-      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -8042,9 +7928,9 @@
       }
     },
     "import-local": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.1.0.tgz",
-      "integrity": "sha512-ASB07uLtnDs1o6EHjKpX34BKYDSqnFerfTOJL2HvMqF70LnxpjkzDB8J44oT9pu4AMPkQwf8jl6szgvNd2tRIg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
+      "integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
       "requires": {
         "pkg-dir": "^4.2.0",
         "resolve-cwd": "^3.0.0"
@@ -8183,11 +8069,11 @@
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA=="
     },
     "is-core-module": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
-      "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.0.tgz",
+      "integrity": "sha512-Dd+Lb2/zvk9SKy1TGCt1wFJFo/MWBPMX5x7KcvLajWTGuomczdQX61PvY5yK6SVACwpoexWo81IfFyoKY2QnTA==",
       "requires": {
-        "hasown": "^2.0.0"
+        "hasown": "^2.0.2"
       }
     },
     "is-data-view": {
@@ -8533,18 +8419,18 @@
       }
     },
     "jackspeak": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.0.tgz",
-      "integrity": "sha512-JVYhQnN59LVPFCEcVa2C3CrEKYacvjRfqIQl+h8oi91aLYQVWRYbxjPcv1bUiUy/kLmQaANrYfNMCO3kuEDHfw==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
       "requires": {
         "@isaacs/cliui": "^8.0.2",
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
     "jake": {
-      "version": "10.9.1",
-      "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.1.tgz",
-      "integrity": "sha512-61btcOHNnLnsOdtLgA5efqQWjnSi/vow5HbI7HMdKKWqvrKR1bLK3BPlJn9gcSaP2ewuamUSMB5XEy76KUIS2w==",
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.2.tgz",
+      "integrity": "sha512-2P4SQ0HrLQ+fw6llpLnOaGAvN2Zu6778SJMrCUwns4fOoG9ayrTiZk3VV8sCPkVZF8ab0zksVpS8FDY5pRCNBA==",
       "requires": {
         "async": "^3.2.3",
         "chalk": "^4.0.2",
@@ -11303,6 +11189,16 @@
           "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
           "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="
         },
+        "form-data": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+          "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -11425,9 +11321,9 @@
       }
     },
     "launch-editor": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.6.1.tgz",
-      "integrity": "sha512-eB/uXmFVpY4zezmGp5XtU21kwo7GBbKB+EQ+UZeWtGb9yAM5xt/Evk+lYH3eRNAtId+ej4u7TYPFZ07w4s7rRw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.8.0.tgz",
+      "integrity": "sha512-vJranOAJrI/llyWGRQqiDM+adrw+k83fvmmx3+nV47g3+36xM15jE+zyZ6Ffel02+xSvuM0b2GDRosXZkbb6wA==",
       "requires": {
         "picocolors": "^1.0.0",
         "shell-quote": "^1.8.1"
@@ -11447,13 +11343,6 @@
         "topojson-client": "^2.1.0",
         "vector-tile": "^1.3.0",
         "whatwg-fetch": "^2.0.3"
-      },
-      "dependencies": {
-        "whatwg-fetch": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
-          "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
-        }
       }
     },
     "lethargy": {
@@ -11834,9 +11723,9 @@
       "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw=="
     },
     "node-releases": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
-      "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw=="
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
+      "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g=="
     },
     "nopt": {
       "version": "1.0.10",
@@ -11878,9 +11767,9 @@
       }
     },
     "nwsapi": {
-      "version": "2.2.10",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.10.tgz",
-      "integrity": "sha512-QK0sRs7MKv0tKe1+5uZIQk/C8XGza4DAnztJG8iD+TpJIORARrCxczA738awHrZoHeTjSSoHqao2teO0dC/gFQ=="
+      "version": "2.2.12",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.12.tgz",
+      "integrity": "sha512-qXDmcVlZV4XRtKFzddidpfVP4oMSGhga+xdMc25mv8kaLUHtgzCDhUxkrN8exkGdTlLNaXj7CV3GtON7zuGZ+w=="
     },
     "object-assign": {
       "version": "4.1.1",
@@ -11893,9 +11782,9 @@
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw=="
     },
     "object-inspect": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
-      "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ=="
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
+      "integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g=="
     },
     "object-is": {
       "version": "1.1.6",
@@ -11965,16 +11854,6 @@
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",
         "es-abstract": "^1.23.2"
-      }
-    },
-    "object.hasown": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.4.tgz",
-      "integrity": "sha512-FZ9LZt9/RHzGySlBARE3VF+gE26TxR38SdmqOqliuTnl9wrKulaQs+4dee1V+Io8VfxqzAfHu6YuRgUy8OHoTg==",
-      "requires": {
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.2",
-        "es-object-atoms": "^1.0.0"
       }
     },
     "object.values": {
@@ -12073,6 +11952,11 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+    },
+    "package-json-from-dist": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz",
+      "integrity": "sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw=="
     },
     "param-case": {
       "version": "3.0.4",
@@ -12183,9 +12067,9 @@
       },
       "dependencies": {
         "lru-cache": {
-          "version": "10.2.2",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.2.tgz",
-          "integrity": "sha512-9hp3Vp2/hFQUiIwKo8XCeFVnrg8Pk3TYNPIR7tJADKi5YfcF7vEaK7avFHTlSy3kOKYaJQaalfEo6YuXdceBOQ=="
+          "version": "10.4.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+          "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
         }
       }
     },
@@ -12228,7 +12112,7 @@
       }
     },
     "pcic-react-leaflet-components": {
-      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#2d6b94b55a3eac746d1c9205288dbdb46bfcf30c",
+      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#7d1303137a561da35f99786b110e54c0dfd9aeef",
       "from": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#add-BCVectorBaseMap",
       "requires": {
         "@testing-library/jest-dom": "^5.16.4",
@@ -12328,12 +12212,12 @@
       "integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q=="
     },
     "postcss": {
-      "version": "8.4.38",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
-      "integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
+      "version": "8.4.40",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.40.tgz",
+      "integrity": "sha512-YF2kKIUzAofPMpfH6hOi2cGnv/HrUlfucspc7pDyvv7kGdqXrfj8SCl/t8owkEgKEuu8ZcRjSOxFxVLqwChZ2Q==",
       "requires": {
         "nanoid": "^3.3.7",
-        "picocolors": "^1.0.0",
+        "picocolors": "^1.0.1",
         "source-map-js": "^1.2.0"
       }
     },
@@ -12566,9 +12450,9 @@
           "integrity": "sha512-eop+wDAvpItUys0FWkHIKeC9ybYrTGbU41U5K7+bttZZeohvnY7M9dZ5kB21GNWiFT2q1OoPTvncPCgSOVO5ow=="
         },
         "yaml": {
-          "version": "2.4.5",
-          "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.4.5.tgz",
-          "integrity": "sha512-aBx2bnqDzVOyNKfsysjA2ms5ZlnjSAW2eG3/L5G/CSujfjLJTJsEw1bGw8kCf04KodQWk1pxlGnZ56CRxiawmg=="
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.5.0.tgz",
+          "integrity": "sha512-2wWLbGbYDiSqqIKoPjar3MPgB94ErzCtrNE1FdqGuaO0pi2JGjmE8aW8TDZwzU7vuxcGRdL/4gPQwQ7hD5AMSw=="
         }
       }
     },
@@ -12680,11 +12564,11 @@
       }
     },
     "postcss-nested": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.0.1.tgz",
-      "integrity": "sha512-mEp4xPMi5bSWiMbsgoPfcP74lsWLHkQbZc3sY+jWYd65CUwXrUaTp0fmNpa01ZcETKlIgUdFN/MpS2xZtqL9dQ==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
+      "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
       "requires": {
-        "postcss-selector-parser": "^6.0.11"
+        "postcss-selector-parser": "^6.1.1"
       }
     },
     "postcss-nesting": {
@@ -12907,9 +12791,9 @@
       }
     },
     "postcss-selector-parser": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.0.tgz",
-      "integrity": "sha512-UMz42UD0UY0EApS0ZL9o1XnLhSTtvvvLe5Dc2H2O56fvRZi+KulDyf5ctDhhtYJBGKStV2FL1fy6253cmLgqVQ==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.1.tgz",
+      "integrity": "sha512-b4dlw/9V8A71rLIDsSwVmak9z2DuBUB7CA1/wSdelNEzqsjoSPeADTWNO09lpH49Diy3/JIZ2bSPB1dI3LJCHg==",
       "requires": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -13268,6 +13152,11 @@
           "version": "0.13.11",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
           "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+        },
+        "whatwg-fetch": {
+          "version": "3.6.20",
+          "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
+          "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg=="
         }
       }
     },
@@ -14190,9 +14079,9 @@
       }
     },
     "semver": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w=="
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A=="
     },
     "send": {
       "version": "0.18.0",
@@ -14588,6 +14477,32 @@
         }
       }
     },
+    "string-width-cjs": {
+      "version": "npm:string-width@4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "requires": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "dependencies": {
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+        }
+      }
+    },
+    "string.prototype.includes": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.0.tgz",
+      "integrity": "sha512-E34CkBgyeqNDcrbU76cDjL5JLcVrtSdYq0MEh/B10r17pRP4ciHLwTgnuLV8Ay6cgEMLkcBkFCKyFZ43YldYzg==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
     "string.prototype.matchall": {
       "version": "4.0.11",
       "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.11.tgz",
@@ -14605,6 +14520,15 @@
         "regexp.prototype.flags": "^1.5.2",
         "set-function-name": "^2.0.2",
         "side-channel": "^1.0.6"
+      }
+    },
+    "string.prototype.repeat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-1.0.0.tgz",
+      "integrity": "sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
       }
     },
     "string.prototype.trim": {
@@ -14665,6 +14589,14 @@
     },
     "strip-ansi": {
       "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "requires": {
+        "ansi-regex": "^5.0.1"
+      }
+    },
+    "strip-ansi-cjs": {
+      "version": "npm:strip-ansi@6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "requires": {
@@ -14751,21 +14683,22 @@
           "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="
         },
         "glob": {
-          "version": "10.4.1",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.1.tgz",
-          "integrity": "sha512-2jelhlq3E4ho74ZyVLN03oKdAZVUa6UDZzFLVH1H7dnoax+y9qyaq8zBkfDIggjniU19z0wU18y16jMB2eyVIw==",
+          "version": "10.4.5",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+          "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
           "requires": {
             "foreground-child": "^3.1.0",
             "jackspeak": "^3.1.2",
             "minimatch": "^9.0.4",
             "minipass": "^7.1.2",
+            "package-json-from-dist": "^1.0.0",
             "path-scurry": "^1.11.1"
           }
         },
         "minimatch": {
-          "version": "9.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
-          "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
+          "version": "9.0.5",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+          "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
           "requires": {
             "brace-expansion": "^2.0.1"
           }
@@ -14845,9 +14778,9 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
     },
     "tailwindcss": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.4.tgz",
-      "integrity": "sha512-ZoyXOdJjISB7/BcLTR6SEsLgKtDStYyYZVLsUtWChO4Ps20CBad7lfJKVDiejocV4ME1hLmyY0WJE3hSDcmQ2A==",
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.7.tgz",
+      "integrity": "sha512-rxWZbe87YJb4OcSopb7up2Ba4U82BoiSGUdoDr3Ydrg9ckxFS/YWsvhN323GMcddgU65QRy7JndC7ahhInhvlQ==",
       "requires": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -14918,9 +14851,9 @@
       }
     },
     "terser": {
-      "version": "5.31.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.31.1.tgz",
-      "integrity": "sha512-37upzU1+viGvuFtBo9NPufCb9dwM0+l9hMxYyWfBA+fbwrPqNJAhbZ6W47bBFnZHKHTUBnMvi87434qq+qnxOg==",
+      "version": "5.31.3",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.31.3.tgz",
+      "integrity": "sha512-pAfYn3NIZLyZpa83ZKigvj6Rn9c/vd5KfYGX7cN1mnzqgDcxWvrU5ZtAfIKhEXz9nRecw4z3LXkjaq96/qZqAA==",
       "requires": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.8.2",
@@ -15398,9 +15331,9 @@
       "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg=="
     },
     "update-browserslist-db": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.16.tgz",
-      "integrity": "sha512-KVbTxlBYlckhF5wgfyZXTWnMn7MMZjMu9XG8bPlliUOP9ThaF4QnhP8qrjrH7DRzHfSk0oQv1wToW+iA5GajEQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.0.tgz",
+      "integrity": "sha512-EdRAaAyk2cUE1wOf2DkEhzxqOQvFOoRJFNS6NeyJ01Gp2beMRpBAINjM2iDXE3KCuKhwnvHIQCJm6ThL2Z+HzQ==",
       "requires": {
         "escalade": "^3.1.2",
         "picocolors": "^1.0.1"
@@ -15578,9 +15511,9 @@
       "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w=="
     },
     "webpack": {
-      "version": "5.92.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.92.0.tgz",
-      "integrity": "sha512-Bsw2X39MYIgxouNATyVpCNVWBCuUwDgWtN78g6lSdPJRLaQ/PUVm/oXcaRAyY/sMFoKFQrsPeqvTizWtq7QPCA==",
+      "version": "5.93.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.93.0.tgz",
+      "integrity": "sha512-Y0m5oEY1LRuwly578VqluorkXbvXKh7U3rLoQCEO04M97ScRr44afGVkI0FQFsXzysk5OgFAxjZAb9rsGQVihA==",
       "requires": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^1.0.5",
@@ -15705,9 +15638,9 @@
           "integrity": "sha512-1APHAyr3+PCamwNw3bXCPp4HFLONZt/yIH0sZp0/469KWNTEy+qN5jQ3GVX6DMZ1UXAi34yVwtTeaG/HpBuuzw=="
         },
         "ws": {
-          "version": "8.17.1",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-          "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ=="
+          "version": "8.18.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+          "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="
         }
       }
     },
@@ -15775,9 +15708,9 @@
       }
     },
     "whatwg-fetch": {
-      "version": "3.6.20",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
-      "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg=="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+      "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
     },
     "whatwg-mimetype": {
       "version": "2.3.0",
@@ -16153,6 +16086,39 @@
         }
       }
     },
+    "wrap-ansi-cjs": {
+      "version": "npm:wrap-ansi@7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        }
+      }
+    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -16170,9 +16136,9 @@
       }
     },
     "ws": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q=="
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="
     },
     "x-is-string": {
       "version": "0.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3525,11 +3525,11 @@
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w=="
     },
     "@types/node": {
-      "version": "22.3.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.3.0.tgz",
-      "integrity": "sha512-nrWpWVaDZuaVc5X84xJ0vNrLvomM205oQyLsRt7OHNZbSHslcWsvgFR7O7hire2ZonjLrWBbedmotmIlJDVd6g==",
+      "version": "22.4.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.4.0.tgz",
+      "integrity": "sha512-49AbMDwYUz7EXxKU/r7mXOsxwFr4BYbvB7tWYxVuLdb2ibd30ijjXINSMAHiEEZk5PCRBmW1gUeisn2VMKt3cQ==",
       "requires": {
-        "undici-types": "~6.18.2"
+        "undici-types": "~6.19.2"
       }
     },
     "@types/node-forge": {
@@ -12096,7 +12096,7 @@
       }
     },
     "pcic-react-leaflet-components": {
-      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#d913ea6e2a978b01481199f6db45f2f457652575",
+      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#0ce6ce5e5a3b231900f950cc48d6b8435e567c57",
       "from": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#add-BCVectorBaseMap",
       "requires": {
         "@testing-library/jest-dom": "^5.16.4",
@@ -15195,9 +15195,9 @@
       "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
     },
     "undici-types": {
-      "version": "6.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.18.2.tgz",
-      "integrity": "sha512-5ruQbENj95yDYJNS3TvcaxPMshV7aizdv/hWYjGIKoANWKjhWNBsr2YEuYZKodQulB1b8l7ILOuDQep3afowQQ=="
+      "version": "6.19.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.6.tgz",
+      "integrity": "sha512-e/vggGopEfTKSvj4ihnOLTsqhrKRN3LeO6qSN/GxohhuRv8qH9bNQ4B8W7e/vFL+0XTnmHPB4/kegunZGA4Org=="
     },
     "unherit": {
       "version": "1.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6106,9 +6106,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.5.7",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.7.tgz",
-      "integrity": "sha512-6FTNWIWMxMy/ZY6799nBlPtF1DFDQ6VQJ7yyDP27SJNt5lwtQ5ufqVvHylb3fdQefvRcgA3fKcFMJi9OLwBRNw=="
+      "version": "1.5.8",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.8.tgz",
+      "integrity": "sha512-4Nx0gP2tPNBLTrFxBMHpkQbtn2hidPVr/+/FTtcCiBYTucqc70zRyVZiOLj17Ui3wTO7SQ1/N+hkHYzJjBzt6A=="
     },
     "emittery": {
       "version": "0.8.1",
@@ -12096,7 +12096,7 @@
       }
     },
     "pcic-react-leaflet-components": {
-      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#713c9bcc5e26bfb51612c6ae82e3b3d55a2d3ee1",
+      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#98f6efe90fabfa26e5377acce788a2770217e59d",
       "from": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#add-BCVectorBaseMap",
       "requires": {
         "@testing-library/jest-dom": "^5.16.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12093,7 +12093,7 @@
       }
     },
     "pcic-react-leaflet-components": {
-      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#f072d08fd7a5982a48ed6af61d25393e6f8ce170",
+      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#f262da820ae6a8a3bc96422902bf44b4b90c0ac3",
       "from": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#add-BCVectorBaseMap",
       "requires": {
         "@testing-library/jest-dom": "^5.16.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12093,7 +12093,7 @@
       }
     },
     "pcic-react-leaflet-components": {
-      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#b662af6f60562445c6373ffa7ecdba633afb3574",
+      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#4876b80d1da7db1b73c707d751c29404f92894ca",
       "from": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#add-BCVectorBaseMap",
       "requires": {
         "@testing-library/jest-dom": "^5.16.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7240,9 +7240,9 @@
       }
     },
     "foreground-child": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.2.1.tgz",
-      "integrity": "sha512-PXUUyLqrR2XCWICfv6ukppP96sdFwWbNEnfEMt7jNsISjMsvaLNinAHNDYyvkyU+SZG2BTSbT5NjG+vZslfGTA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
+      "integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
       "requires": {
         "cross-spawn": "^7.0.0",
         "signal-exit": "^4.0.1"
@@ -12093,7 +12093,7 @@
       }
     },
     "pcic-react-leaflet-components": {
-      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#b75214332c6c204e1be70b9387f301cca76b3f44",
+      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#9f25136aec31d126d08d30e4ad6dd98b79e99e47",
       "from": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#add-BCVectorBaseMap",
       "requires": {
         "@testing-library/jest-dom": "^5.16.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12096,7 +12096,7 @@
       }
     },
     "pcic-react-leaflet-components": {
-      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#599ffe817de0f7d1416ceba264df999eb82d3b11",
+      "version": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#4421dd2932c143df666340afb69efe6f43af6a44",
       "from": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#add-BCVectorBaseMap",
       "requires": {
         "@testing-library/jest-dom": "^5.16.4",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "path-browserify": "^1.0.1",
     "pcic-react-components": "git+https://git@github.com/pacificclimate/pcic-react-components.git#3.1.0",
     "pcic-react-external-text": "git+https://git@github.com/pacificclimate/pcic-react-external-text.git#1.0.0",
-    "pcic-react-leaflet-components": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#3.0.1",
+    "pcic-react-leaflet-components": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#add-BCVectorBaseMap",
     "process": "^0.11.10",
     "proj4": "^2.7.5",
     "proj4leaflet": "^1.0.2",

--- a/src/components/maps/ClimateLayer/ClimateLayer.js
+++ b/src/components/maps/ClimateLayer/ClimateLayer.js
@@ -48,7 +48,7 @@ export default class ClimateLayer extends React.Component {
       this.props
     )) {
       console.log('### ClimateLayer: unsettled props', this.props)
-      return <Loader/>;
+      return <Loader />;
     }
     const {
       fileMetadata, variableSpec, season, variableConfig, unitsSpecs,

--- a/src/components/maps/ClimateLayer/ClimateLayer.js
+++ b/src/components/maps/ClimateLayer/ClimateLayer.js
@@ -78,7 +78,7 @@ export default class ClimateLayer extends React.Component {
         logscale={getWmsLogscale(variableConfig, variableId)}
         noWrap={true}
         numcolorbands={wmsNumcolorbands}
-        opacity={0.7}
+        opacity={0.0}
         // srs={"EPSG:3005"}
         transparent={true}
         version={'1.1.1'}

--- a/src/components/maps/DataMap/DataMap.js
+++ b/src/components/maps/DataMap/DataMap.js
@@ -10,7 +10,7 @@ import filter from 'lodash/fp/filter';
 import mapValues from 'lodash/fp/mapValues';
 import cond from 'lodash/fp/cond';
 
-import { BCBaseMap } from 'pcic-react-leaflet-components';
+import { BCVectorBaseMap } from 'pcic-react-leaflet-components';
 import ClimateLayer from '../ClimateLayer';
 import LayerValuePopup from '../LayerValuePopup';
 import SimpleGeoJSON from '../SimpleGeoJSON';
@@ -134,7 +134,7 @@ class DataMapDisplay extends React.Component {
     } = this.props;
 
     return (
-      <BCBaseMap
+      <BCVectorBaseMap
         {...baseMapProps}
       // FIXME: Popups are disabled because the CE ncWMS does not allow
       //  GetFeatureInfo requests, which are required to fill the popup.
@@ -153,7 +153,7 @@ class DataMapDisplay extends React.Component {
         }
         <SimpleGeoJSON data={region} fill={false} color={'#212529'} weight={3.2} />
         {children}
-      </BCBaseMap>
+      </BCVectorBaseMap>
     );
   }
 }


### PR DESCRIPTION
Draft for now, the expected changes following approval from a PR in pcic-react-leaflet-components include:

- Updates to DataMap.js to use the new BC vector base maps.
- Updated package-lock to the latest version of pcic-react-leaflet-components. 
- Restore the opacity of the ncWMS layer.  
