### PR TITLE
Use whole num precision for projected change

### DIFF
--- a/public/external-text/default.yaml
+++ b/public/external-text/default.yaml
@@ -72,7 +72,8 @@ tabs:
         - variable: tas
           display: absolute
           displayUnits: °C
-          precision: 1
+          basePrecision: 1
+          projectedPrecision: 1
           seasons:
             - annual
             - winter
@@ -83,7 +84,8 @@ tabs:
         - variable: pr
           display: relative
           displayUnits: "%"
-          precision: 2
+          basePrecision: 2
+          projectedPrecision: 0
           seasons:
             - annual
             - winter
@@ -93,7 +95,8 @@ tabs:
         - variable: snow
           display: relative
           displayUnits: "%"
-          precision: 2
+          basePrecision: 2
+          projectedPrecision: 0
           seasons:
             - annual
             - winter
@@ -102,25 +105,29 @@ tabs:
         - variable: gdd
           display: absolute
           displayUnits: degree-days
-          precision: 0
+          basePrecision: 0
+          projectedPrecision: 0
           seasons:
             - annual
         - variable: ffd
           display: absolute
           displayUnits: days
-          precision: 0
+          basePrecision: 0
+          projectedPrecision: 0
           seasons:
             - annual
         - variable: hdd
           display: absolute
           displayUnits: degree-days
-          precision: 0
+          basePrecision: 0
+          projectedPrecision: 0
           seasons:
             - annual
         - variable: cdd
           display: absolute
           displayUnits: degree-days
-          precision: 0
+          basePrecision: 0
+          projectedPrecision: 0
           seasons:
             - annual
     notes: |

--- a/src/components/app-root/MapsTabBody/MapsTabBody.js
+++ b/src/components/app-root/MapsTabBody/MapsTabBody.js
@@ -381,7 +381,7 @@ export default class MapsTabBody extends React.PureComponent {
               metadata={this.props.metadata}
               variableConfig={variableConfig}
               unitsSpecs={unitsSpecs}
-              baseMapTilesUrl={window.env.REACT_APP_YNWT_BASE_MAP_TILES_URL}
+              baseMapTilesUrl={window.env.REACT_APP_BC_BASE_MAP_TILES_URL}
             >
               <MapInstanceProvider
                 setMapInstance={this.setProjectedMapInstance}

--- a/src/components/data-displays/Summary/Summary.js
+++ b/src/components/data-displays/Summary/Summary.js
@@ -200,7 +200,13 @@ class Summary extends React.Component {
         </thead>
         <tbody>
           {map(([row, rowSummaryStatistics]) => {
-            const { variable, display, precision, seasons } = row;
+            const {
+              variable,
+              display,
+              basePrecision,
+              projectedPrecision,
+              seasons,
+            } = row;
             return map((season) => {
               const seasonSpec = isString(season) ? { season } : season;
 
@@ -244,7 +250,7 @@ class Summary extends React.Component {
               // Retrieve the season median from the seasonMediansMap
               const means = rowSummaryStatistics.summaryStats.seasonMeans;
               const displayBaselineMeans = baselineFormat(
-                precision,
+                basePrecision,
                 Number.parseFloat([means[seasonSpec.season]]),
               );
 
@@ -262,7 +268,7 @@ class Summary extends React.Component {
                   percentileValues: displayPercentileValues,
                   baselineMeanVal: displayBaselineMeans,
                 },
-                format: displayFormat(precision),
+                format: displayFormat(projectedPrecision),
                 isLong,
                 unitsSuffix,
               };


### PR DESCRIPTION
Following a recent update to the [baseline precision of PR and PRSN variables](https://github.com/pacificclimate/plan2adapt-v2/pull/279), a need has been established for us to control the precision of a variable's baseline and projected change values independently. This PR introduces basePrecision and projectedPrecision to fine-tune how values are displayed in the summary statistics table. The projected change precision was set according to what was requested from RCI.

Resolves #280 

Demo: https://beehive.pacificclimate.org/plan2adapt/app