### PR TITLE
Fix baseMapTilesUrl

### DIFF
--- a/src/components/app-root/MapsTabBody/MapsTabBody.js
+++ b/src/components/app-root/MapsTabBody/MapsTabBody.js
@@ -381,7 +381,7 @@ export default class MapsTabBody extends React.PureComponent {
               metadata={this.props.metadata}
               variableConfig={variableConfig}
               unitsSpecs={unitsSpecs}
-              baseMapTilesUrl={window.env.REACT_APP_YNWT_BASE_MAP_TILES_URL}
+              baseMapTilesUrl={window.env.REACT_APP_BC_BASE_MAP_TILES_URL}
             >
               <MapInstanceProvider
                 setMapInstance={this.setProjectedMapInstance}


### PR DESCRIPTION
I was unable to reproduce the failing URL error in Brave or Firefox, but I did identify an undefined variable in the code and replaced it with the correct one. I'm reasonably confident this fix will resolve #281.